### PR TITLE
Advertise executable recipe-backed models

### DIFF
--- a/grid_api/routers/AGENTS.md
+++ b/grid_api/routers/AGENTS.md
@@ -42,7 +42,8 @@ transport, accounts, stats, health/metrics.
   tokens are verified at `/v1/auth/google/exchange`; `/v1/auth/service/bind`
   binds an app subject after recent Google/SIWE proof. `/v1/accounts/bridges`
   bootstraps a bounded service client only when separately enabled.
-- `stats.py` - `GET /v1/workers`, progress polling, model status, usage totals,
+- `stats.py` - `GET /v1/workers`, progress polling, recipe-aware model status
+  (raw worker checkpoints plus executable recipe-backed public model names), usage totals,
   model stats, wallet earnings, `GET /v1/payouts/public` (aggregate payout
   transparency), `GET /v1/jobs/recent` (PUBLIC redacted job feed: model, worker
   handle, timing, den, prompt/result hashes + signed flag — NEVER content,

--- a/grid_api/routers/stats.py
+++ b/grid_api/routers/stats.py
@@ -198,11 +198,35 @@ async def _perf_by_model(session, since: datetime | None) -> dict[tuple[str, str
     return out
 
 
+def _recipe_model_capacity(workers: list[dict], recipe_defs) -> dict[tuple[str, str], set[int]]:
+    """Map recipe-backed public model names to workers that can execute them.
+
+    Workers advertise installed checkpoints, while clients request the recipe's
+    model name. A worker counts only when it serves the recipe modality and has
+    every required checkpoint itself; satisfying requirements across different
+    workers would advertise capacity that cannot actually execute one job.
+    """
+    capacity: dict[tuple[str, str], set[int]] = {}
+    for recipe in recipe_defs:
+        job_type = recipe.job_type
+        required = set(recipe.required_models or [])
+        if job_type not in ("image", "video", "3d") or not required:
+            continue
+        key = (recipe.model_name, job_type)
+        for index, worker in enumerate(workers):
+            if job_type not in (worker.get("job_types") or ["text"]):
+                continue
+            if required.issubset(set(worker.get("models") or [])):
+                capacity.setdefault(key, set()).add(index)
+    return capacity
+
+
 @router.get("/v1/status/models")
 async def status_models():
     """Models currently served, with how many workers serve each — plus recent
     per-model performance (t/s, TTFT, avg latency) from the last 24h of ledger
-    timing, so a picker can show live availability AND how fast each model is."""
+    timing. Includes recipe-backed public model names when compatible workers
+    have every required checkpoint, not just raw worker-advertised checkpoints."""
     workers = await _active_workers()
     counts: dict[str, int] = {}
     types: dict[str, set] = {}
@@ -230,6 +254,31 @@ async def status_models():
             "avg_ttft_s": p.get("avg_ttft_s"),
             "avg_latency_s": p.get("avg_latency_s"),
         })
+    # A governed recipe can expose a new client-facing model name while routing
+    # to an existing worker checkpoint. Surface those virtual models here so
+    # status consumers use the same recipe-aware availability as generation.
+    try:
+        from ..services import recipes
+
+        virtual = _recipe_model_capacity(workers, recipes.list_recipes())
+        for (model_name, job_type), worker_indexes in virtual.items():
+            if model_name in counts or not worker_indexes:
+                continue
+            p = perf.get((model_name, job_type)) or {}
+            out.append({
+                "name": model_name,
+                "count": len(worker_indexes),
+                "type": job_type,
+                "max_context_length": None,
+                "samples": p.get("samples", 0),
+                "tokens_per_s": p.get("tokens_per_s"),
+                "avg_ttft_s": p.get("avg_ttft_s"),
+                "avg_latency_s": p.get("avg_latency_s"),
+                "recipe_backed": True,
+            })
+    except Exception as e:
+        logger.warning("Could not expand recipe-backed model status: %s", e)
+    out.sort(key=lambda item: (-item["count"], item["name"].lower()))
     return out
 
 

--- a/grid_api/routers/tests/test_stats_recipe_models.py
+++ b/grid_api/routers/tests/test_stats_recipe_models.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 AI Power Grid
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from types import SimpleNamespace
+
+import pytest
+
+from grid_api.routers import stats
+from grid_api.routers.stats import _recipe_model_capacity
+
+
+def _recipe(name="LTX Director 2.0", required=None, job_type="video"):
+    return SimpleNamespace(
+        model_name=name,
+        required_models=required or ["LTX-2.3"],
+        job_type=job_type,
+    )
+
+
+def test_recipe_model_capacity_maps_public_name_to_checkpoint_worker():
+    workers = [
+        {"models": ["LTX-2.3"], "job_types": ["image", "video"]},
+        {"models": ["z-image-turbo"], "job_types": ["image"]},
+    ]
+
+    capacity = _recipe_model_capacity(workers, [_recipe()])
+
+    assert capacity == {("LTX Director 2.0", "video"): {0}}
+
+
+def test_recipe_requirements_must_be_colocated_on_one_worker():
+    workers = [
+        {"models": ["checkpoint-a"], "job_types": ["video"]},
+        {"models": ["checkpoint-b"], "job_types": ["video"]},
+    ]
+    recipe = _recipe(required=["checkpoint-a", "checkpoint-b"])
+
+    assert _recipe_model_capacity(workers, [recipe]) == {}
+
+
+def test_recipe_capacity_requires_matching_modality():
+    workers = [{"models": ["LTX-2.3"], "job_types": ["image"]}]
+
+    assert _recipe_model_capacity(workers, [_recipe(job_type="video")]) == {}
+
+
+@pytest.mark.asyncio
+async def test_status_models_advertises_executable_recipe_name(monkeypatch):
+    workers = [
+        {
+            "models": ["LTX-2.3"],
+            "job_types": ["image", "video"],
+            "max_context_length": 2048,
+        }
+    ]
+
+    class _SessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    async def _active_workers():
+        return workers
+
+    async def _new_session():
+        return _SessionContext()
+
+    async def _perf_by_model(session, since):
+        return {}
+
+    monkeypatch.setattr(stats, "_active_workers", _active_workers)
+    monkeypatch.setattr(stats, "new_session", _new_session)
+    monkeypatch.setattr(stats, "_perf_by_model", _perf_by_model)
+    monkeypatch.setattr("grid_api.services.recipes.list_recipes", lambda: [_recipe()])
+
+    result = await stats.status_models()
+
+    director = next(item for item in result if item["name"] == "LTX Director 2.0")
+    assert director == {
+        "name": "LTX Director 2.0",
+        "count": 1,
+        "type": "video",
+        "max_context_length": None,
+        "samples": 0,
+        "tokens_per_s": None,
+        "avg_ttft_s": None,
+        "avg_latency_s": None,
+        "recipe_backed": True,
+    }


### PR DESCRIPTION
Summary: expose executable recipe-backed public model names in the model-status endpoint, require all recipe checkpoints on one compatible worker, and cover the LTX Director route at helper and endpoint level. Verification: 58 router tests passed and diff check is clean.