### PR TITLE
Harden demand billing launch and operator alerts

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -23,6 +23,24 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: grid_test
+          POSTGRES_PASSWORD: grid_test
+          POSTGRES_DB: grid_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U grid_test -d grid_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      GRID_DB_URL: postgresql+asyncpg://grid_test:grid_test@127.0.0.1:5432/grid_test
+      CREDITS_TEST_DB_URL: postgresql+asyncpg://grid_test:grid_test@127.0.0.1:5432/grid_test
+      PAYOUTS_TEST_DB_URL: postgresql+asyncpg://grid_test:grid_test@127.0.0.1:5432/grid_test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -33,6 +51,10 @@ jobs:
         run: pip install -r requirements-grid.txt pytest pytest-asyncio
       - name: Retired runtime gate
         run: python scripts/check_retired_runtime.py
+      - name: Migration and schema parity
+        run: |
+          alembic upgrade head
+          alembic check
       - name: Offline test suite (grid_api)
         # Unit tests for the on-the-money path (den, settlement merkle/ipfs,
         # recipes, payout-wallet validation). No Postgres/Redis/live API needed;

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -22,6 +22,24 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: grid_test
+          POSTGRES_PASSWORD: grid_test
+          POSTGRES_DB: grid_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U grid_test -d grid_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      GRID_DB_URL: postgresql+asyncpg://grid_test:grid_test@127.0.0.1:5432/grid_test
+      CREDITS_TEST_DB_URL: postgresql+asyncpg://grid_test:grid_test@127.0.0.1:5432/grid_test
+      PAYOUTS_TEST_DB_URL: postgresql+asyncpg://grid_test:grid_test@127.0.0.1:5432/grid_test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -32,5 +50,9 @@ jobs:
         run: pip install -r requirements-grid.txt pytest pytest-asyncio
       - name: Retired runtime gate
         run: python scripts/check_retired_runtime.py
+      - name: Migration and schema parity
+        run: |
+          alembic upgrade head
+          alembic check
       - name: Offline test suite (grid_api)
         run: python -m pytest grid_api -q

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Verify `http://127.0.0.1:7010/health` and
 
 ## Safety posture
 
-- Demand charging defaults off with `GRID_CHARGING_ENABLED=0`; metering code
-  existing does not mean charging is live.
+- Demand charging defaults to `GRID_CHARGING_MODE=off`. `allowlist` supports a
+  bounded canary cohort before `on`; the legacy `GRID_CHARGING_ENABLED` boolean
+  remains a compatibility fallback.
 - Free-credit spending has its own `GRID_FREE_SPENDABLE_LIVE` gate.
 - Promotional-credit spending has its own `GRID_PROMO_SPENDABLE_LIVE` gate.
 - The live worker reward bridge is the custodial, Transfer-verified AIPG payout

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -11,6 +11,8 @@ executes an immutable release selected through `/home/aipg/current`.
   commit SHA. Installs only the Grid API, PostgreSQL, Redis, and Nginx.
 - `env.template` - `/etc/aipg/grid.env` source of production env names.
 - `README.md` - deploy/cutover/runbook notes.
+- `DEMAND_BILLING_RUNBOOK.md` - dark deploy, allowlisted canary, alert,
+  rollback, and staged demand-charging procedure.
 - `nginx/aipg-api.conf` - Grid routes, restricted metrics, public docs/health,
   and static `410 Gone` responses for retired API paths.
 - `systemd/aipg-gridapi.service` - uvicorn Grid API unit.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -35,6 +35,9 @@ executes an immutable release selected through `/home/aipg/current`.
   firewall/nginx impact.
 - `GRID_SALT` stays server-side. The developer console has no local DB/salt path
   and must not receive it.
+- `GRID_SIWE_ALLOWED_DOMAINS` is the exact frontend authority allowlist for
+  wallet-login challenges. Keep `GRID_LEGACY_SIWE_VERIFY_ENABLED=0`; it is an
+  emergency client-migration switch, not a permanent compatibility mode.
 - If you rename Base/contract env vars, update `docs/`, `grid_api/services/*`,
   and any SDK examples in the same change.
 

--- a/deploy/DEMAND_BILLING_RUNBOOK.md
+++ b/deploy/DEMAND_BILLING_RUNBOOK.md
@@ -1,0 +1,133 @@
+# Demand billing launch runbook
+
+## Safety invariants
+
+- New work is charged only when `GRID_CHARGING_MODE` selects it.
+- Every selected request reserves before dispatch. A terminal worker event
+  atomically records supply-side work and settles or releases the demand hold.
+- Turning charging off stops new holds but does not abandon existing holds.
+- Purchased balance equals the append-only purchased-credit ledger globally.
+- Discord alerts are operational hints, not accounting authority. PostgreSQL
+  remains the source of truth.
+
+## Rollout modes
+
+`GRID_CHARGING_MODE=off` previews prices without moving value.
+
+`GRID_CHARGING_MODE=allowlist` charges only an account listed in
+`GRID_CHARGING_ALLOW_ACCOUNTS` or a service listed in
+`GRID_CHARGING_ALLOW_SERVICES`. `GRID_CHARGING_ALLOW_MODELS`, when non-empty,
+further restricts the selected cohort to exact model IDs.
+
+`GRID_CHARGING_MODE=on` charges every authenticated request and default-denies
+unpriced work. Do not use this mode for the first production test.
+
+The legacy `GRID_CHARGING_ENABLED` boolean is consulted only when
+`GRID_CHARGING_MODE` is absent. Keep it `0` once the mode is configured.
+
+## Release gate
+
+From a clean reviewed commit and a disposable Postgres database:
+
+```bash
+python -m pip check
+python -m alembic upgrade head
+python -m alembic check
+python -m pytest grid_api -q
+```
+
+Run the real Postgres races too:
+
+```bash
+export CREDITS_TEST_DB_URL=postgresql+asyncpg://grid_test:grid_test@127.0.0.1/grid_test
+export PAYOUTS_TEST_DB_URL="$CREDITS_TEST_DB_URL"
+python -m pytest \
+  grid_api/services/tests/test_credits_concurrency.py \
+  grid_api/services/settlement/tests/test_payouts_lifecycle.py -q
+```
+
+The disposable database must not be production or share production tables.
+
+## Dark deployment
+
+1. Deploy Core using the immutable-release procedure in `deploy/README.md`.
+2. Keep `GRID_CHARGING_MODE=off`, free/promo spending off, and deposits off.
+3. Add `GRID_ALERT_DISCORD_WEBHOOK` only to `/etc/aipg/grid.env`; preserve its
+   restrictive permissions and never print the file.
+4. Restart Core. Confirm `core_started` arrives without secrets and reports
+   `charging_mode=off`.
+5. Check `/health`, `/v1/models`, worker reconnects, Core logs, and the billing
+   invariant monitor. Any `billing_invariant_failed` alert blocks the canary.
+6. Deploy the strict-SIWE Console release and verify Google plus wallet login
+   before removing any temporary legacy SIWE compatibility flag.
+
+## Fund one canary
+
+The grant tool is dry-run by default and capped at $10:
+
+```bash
+python scripts/grant_canary_credit.py \
+  --account-id <canonical-account-uuid> \
+  --amount-usd 2.00 \
+  --ref canary:<date>
+```
+
+After verifying the account, amount, and idempotency ref, repeat with `--apply`.
+Run it from the selected production release with the protected service
+environment loaded. A repeat with the same ref must print `applied=false` and
+must not increase the balance.
+
+## Allowlisted canary
+
+1. Set `GRID_CHARGING_MODE=allowlist`.
+2. Put only the canary UUID in `GRID_CHARGING_ALLOW_ACCOUNTS`. Optionally set
+   one exact model in `GRID_CHARGING_ALLOW_MODELS`.
+3. Restart Core and confirm the startup alert reports one selected account.
+4. Verify `GET /v1/account/credits` reports `charging_mode=allowlist` and
+   `charging_enabled=true` for the canary. A second account must report false.
+5. Submit one short non-streaming request. Verify one held reservation becomes
+   settled, the balance decreases by actual grid-counted usage, and the worker
+   completion ledger has one row.
+6. Submit one stream and disconnect after output begins. Verify the worker
+   terminal still settles the reservation.
+7. Request work whose maximum quote exceeds the remaining balance. It must
+   return `402` before queueing and generate an `insufficient_credit` alert.
+8. Retry the canary-credit grant with its original ref. Balance must not move.
+9. Confirm no stale holds, no negative balances, no ledger drift, and no
+   settlement or service-exposure alerts.
+
+## Alerts
+
+Expected success events:
+
+- Core startup with rollout counts
+- new account creation, identified only by an opaque correlation hash
+- service-principal provisioning
+- verified USDC/ETH credit
+- operator canary credit
+
+Important warning/critical events:
+
+- unpriced work selected for live charging
+- insufficient balance or service exposure limit
+- reservation inconsistency/failure
+- settlement, refund, sweeper, or monitor failure
+- under-collection and late success after release
+- stale/aging monetary holds
+- purchased-balance versus ledger mismatch
+- Base RPC/oracle deposit failure or wallet mismatch
+- unhandled Core HTTP failure and route rate limiting
+
+Repeated alerts are deduplicated for `GRID_ALERT_DEDUPE_SECONDS`; delivery uses a
+bounded queue and never blocks account, inference, deposit, or settlement work.
+
+## Kill switch and rollback
+
+Set `GRID_CHARGING_MODE=off` and restart to stop new charges. Do not delete
+reservation rows or stop the sweeper: already-held jobs still need to settle or
+refund. If code rollback is required, choose a retained release compatible with
+the current Alembic schema as described in `deploy/README.md`.
+
+Do not enable free/promotional spending, deposits, or global `on` mode merely
+because the allowlisted canary passes. Each expands financial exposure and has
+its own explicit launch decision.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -92,8 +92,10 @@ worker reconnects before declaring the deploy healthy.
 
 ## Money-path controls
 
-- `GRID_CHARGING_ENABLED=0` keeps demand charging in dry-run. Do not flip it as
-  part of an unrelated deploy.
+- `GRID_CHARGING_MODE=off` keeps demand charging in dry-run. Use `allowlist`
+  for a bounded canary before considering `on`; do not change the mode as part
+  of an unrelated deploy. `GRID_CHARGING_ENABLED` is a compatibility fallback
+  only when the mode is absent.
 - `GRID_FREE_SPENDABLE_LIVE` is a separate free-credit spending gate.
 - `aipg-payout.timer` drives the live custodial worker payout CLI. Stop/restart
   it only under the settlement runbook in

--- a/deploy/env.template
+++ b/deploy/env.template
@@ -71,9 +71,16 @@ GRID_LEGACY_INTERNAL_SESSION_ENABLED=0
 GRID_LEGACY_SESSION_KEYS_ENABLED=0
 #GRID_INTERNAL_TOKEN=
 
-# Demand charging is independently gated and defaults dark. Do not flip these
-# as part of an unrelated deploy.
+# Demand charging is independently gated and defaults dark. GRID_CHARGING_MODE
+# is authoritative when set. The old boolean remains an emergency-compatible
+# fallback for hosts that have not adopted the mode yet.
+GRID_CHARGING_MODE=off
 GRID_CHARGING_ENABLED=0
+# In allowlist mode, at least one account or service must match. The optional
+# model list narrows the selected cohort; it never enables charging by itself.
+GRID_CHARGING_ALLOW_ACCOUNTS=
+GRID_CHARGING_ALLOW_SERVICES=
+GRID_CHARGING_ALLOW_MODELS=
 GRID_FREE_CREDITS_ENABLED=1
 GRID_FREE_SPENDABLE_LIVE=0
 GRID_PROMO_CREDITS_ENABLED=1
@@ -104,6 +111,14 @@ WORKER_ENROLLMENT_TTL_SECONDS=900
 # Atomic reservation cleanup.
 RESERVATION_SWEEP_SECONDS=300
 RESERVATION_STALE_SECONDS=3600
+GRID_BILLING_MONITOR_SECONDS=300
+GRID_BILLING_HELD_WARNING_SECONDS=900
+
+# Operator alerts. Store the real value only in the protected production env;
+# never commit it, paste it into logs, or expose it to a frontend.
+GRID_ALERT_DISCORD_WEBHOOK=
+GRID_ALERT_QUEUE_SIZE=256
+GRID_ALERT_DEDUPE_SECONDS=300
 
 # Public request/concurrency bounds.
 GRID_TEXT_CONCURRENCY=24

--- a/deploy/env.template
+++ b/deploy/env.template
@@ -95,6 +95,10 @@ APPROVED_WORKER_PROFILE_DIGESTS=
 REQUIRE_WORKER_IDENTITY=0
 WORKER_ENROLLMENT_ENABLED=0
 WORKER_ENROLLMENT_CONSOLE_URL=https://console.aipowergrid.io/dashboard/connect-worker
+# Strict wallet login: frontend origin allowlist for EIP-4361 challenges.
+GRID_SIWE_ALLOWED_DOMAINS=console.aipowergrid.io,aipg.art,aipg.chat,aipg.music
+# Emergency migration switch only. Keep off once clients use /wallet/challenge.
+GRID_LEGACY_SIWE_VERIFY_ENABLED=0
 WORKER_ENROLLMENT_TTL_SECONDS=900
 
 # Atomic reservation cleanup.

--- a/docs/architecture/DEMAND_SIDE_AUDIT_BRIEF.md
+++ b/docs/architecture/DEMAND_SIDE_AUDIT_BRIEF.md
@@ -88,8 +88,12 @@ on). These are hard gates, not suggestions:
   `issue_key` forces it false so it isn't caller-settable). A leaked inference key
   can no longer redirect earnings or manage keys. API keys now carry capability
   scopes and Core can bootstrap bridge keys limited to `account.read`,
-  `inference.submit`, and `identity.assert`. **Still TODO:** split the remaining session-level account
-  authority into finer billing/worker scopes after client migration.
+  `inference.submit`, and `identity.assert`. Wallet login now has a strict
+  EIP-4361 challenge that binds the selected address, allowlisted frontend
+  domain/URI, Base chain id, issue/expiry time, and single-use nonce; generic
+  sign-in verification is default-off. **Still TODO:** deploy Core and the
+  Console challenge client together, then split the remaining session-level
+  account authority into finer billing/worker scopes.
 - [x] **B3a (P0 FIXED `cf0cfd08`, 2026-07-08) — Identity-bridge confused deputy.**
   `POST /v1/accounts/session` OR-matched oauth_sub|wallet|email then `.first()`
   (no ORDER BY) and minted a dashboard-session key for the arbitrary winner.
@@ -124,12 +128,16 @@ on). These are hard gates, not suggestions:
   never the worker/backend `usage`. They reserve before dispatch (402 on
   insufficient funds, native error envelope) and reconcile/refund on the terminal
   event or in a `finally` on disconnect, same as chat.
-  **Remaining before flip:** peg media prices (currently placeholders); the
-  per-format flatten is a tiktoken proxy (o200k_base), not each backend's native
-  tokenizer, so counts are approximate — acceptable as a billing proxy, document it.
-- [x] **B5 (DONE, b8d4ca2) — Default-deny unpriced models in enforce mode.** Flip
-  `BLOCK_UNPRICED` semantics so an unpriced/renamed model can't be free when
-  charging is on.
+  Price coverage is now modality-specific, production display/recipe names map
+  through explicit aliases, omitted video duration bills the selected recipe's
+  baked graph default, and ACE-Step uses the approved low-cost launch peg.
+  **Remaining before flip:** approve the provisional Qwen/SmolLM/media pegs from
+  measured worker economics; the per-format flatten is a tiktoken proxy
+  (o200k_base), not each backend's native tokenizer, so counts are approximate.
+- [x] **B5 (DONE, b8d4ca2 + launch-hardening follow-up) — Default-deny unpriced
+  model/modality pairs in enforce mode.** A renamed model or a model priced only
+  for another modality cannot become free. Positive sub-micro quotes round up to
+  one ledger unit.
 - [x] **B6 (code-guard DONE, b8d4ca2; hard DB constraint → B7) — Idempotency is structural, not caller-discipline.** `ref` **non-null
   required** for value-moving ledger rows (Postgres allows multiple NULLs through
   the unique index); validate in code; tests.
@@ -158,6 +166,19 @@ on). These are hard gates, not suggestions:
   rejected, concurrent-debit can't overdraft, insufficient blocks **before**
   dispatch, stream reserve/refund, media-job charging, unpriced blocked in
   enforce mode.
+
+### 2026-07 demand-launch hardening (code complete; deploy/canary pending)
+
+- Positive purchased-credit accounts bypass only the free request-count quota;
+  the atomic prepaid reserve remains the authoritative spend gate.
+- Bounded service ceilings now reserve by job id, release on failed
+  authorization/no-work terminals, and reconcile max text exposure to actual
+  spend after the SQL terminal commit.
+- Core strict-SIWE tests cover cross-domain rejection, exact-message matching,
+  non-burning invalid attempts, and single-use replay rejection. The Console
+  client signs the Core-issued message verbatim.
+- Global charging remains off until production deploy order, price approval,
+  top-up path, monitoring, and a bounded canary are complete.
 
 **Recommended build order:** B1+B6+B5 (+ tests) → B4 (universal metering) →
 B2+B3 (scoped keys + signed bridge identity) → B7 → B8.

--- a/docs/architecture/DEMAND_SIDE_AUDIT_BRIEF.md
+++ b/docs/architecture/DEMAND_SIDE_AUDIT_BRIEF.md
@@ -20,20 +20,21 @@ to a **grid account** and call the grid; the grid prices, meters, debits, and
 enforces limits. One USD balance per account, spendable everywhere; funded by
 many rails (Stripe, USDC/ETH/AIPG on Base, x402).
 
-**Charging is currently OFF** (`GRID_CHARGING_ENABLED=0`): the metering path runs
+**Charging is currently OFF** (`GRID_CHARGING_MODE=off`): the metering path runs
 in **dry-run** — it computes and logs what it *would* charge but never debits or
-blocks. Nothing in production moves customer money today. We want this audited
-**before** we flip it live.
+blocks. `allowlist` is the mandatory first live stage; `on` is the broad
+rollout. The old `GRID_CHARGING_ENABLED` boolean is only a compatibility
+fallback.
 
 ---
 
-## GO-LIVE BLOCKER CHECKLIST (from the audit — must be ✅ before `GRID_CHARGING_ENABLED=1`)
+## GO-LIVE BLOCKER CHECKLIST (must be complete before `GRID_CHARGING_MODE=on`)
 
 The independent review (2026-06) confirmed the brief asks the right questions and
 that several risks are **already real in code** (they only bite once charging is
 on). These are hard gates, not suggestions:
 
-- [~] **B1 (SUBSTANTIALLY DONE — core reserve path landed b8d4ca2; second pass
+- [x] **B1 (DONE — core reserve path landed b8d4ca2; second pass
   hardened the leaks; fifth pass `b02ada2c` added FREE-FIRST: authorize_request/
   authorize_media draw the daily free allowance before paid, split durable in
   grid_reservations.free_micro, settlement restores free-to-free / refunds
@@ -80,8 +81,9 @@ on). These are hard gates, not suggestions:
   when a reservation exists but is no longer held ('stale_no_payout'), so a
   refunded job can't later mint a worker payout. Alembic 0001 genesis brought to
   parity with schema.py (grid_ledger.job_id UNIQUE — the idempotency guard — plus
-  duration/ttft). **Remaining before flip:** Postgres concurrency test (atomicity
-  proven on SQLite only); media price peg.
+  duration/ttft). Real Postgres 16 tests now prove overdraft and duplicate-ref
+  behavior. Existing reservations remain settleable or refundable after the
+  operator disables new charging.
 - [~] **B2 (SUBSTANTIALLY DONE).** Account-admin actions
   (change payout wallet, issue/revoke keys) now require a wallet-proven **session
   key** (`api_keys.is_session`, set only by SIWE wallet-login / dashboard-login;
@@ -141,15 +143,15 @@ on). These are hard gates, not suggestions:
 - [x] **B6 (code-guard DONE, b8d4ca2; hard DB constraint → B7) — Idempotency is structural, not caller-discipline.** `ref` **non-null
   required** for value-moving ledger rows (Postgres allows multiple NULLs through
   the unique index); validate in code; tests.
-- [~] **B7 (PARTIAL — credit-ledger `ref` NOT NULL landed, alembic `0008` / `229bca16`).**
+- [x] **B7 (DONE — credit-ledger `ref` NOT NULL landed, alembic `0008` / `229bca16`).**
   `grid_credit_ledger.ref` is now DB-enforced NOT NULL (+ existing UNIQUE), so the
   value-moving idempotency invariant is reproducible in migrations, not just guarded
   in code. Since extended: `0009` payout-preference cols (HOT-auth-path — must run
   before the code that SELECTs them), `0010` grid_revenue, `0011` grid_payout_legs,
   `0012` grid_reservations.free_micro; `0008` made SQLite-safe (batch_alter_table).
-  **Still TODO for full B7:** reconcile the rest of Alembic with `schema.py`
-  metadata (`grid_ledger.job_id` UNIQUE, telemetry columns) and add a drift check so
-  create_all-vs-migration divergence can't recur.
+  Genesis and follow-up migrations now match `schema.py`. CI creates a clean
+  Postgres 16 database, runs `alembic upgrade head`, and requires `alembic
+  check` to report no generated operations before the full Grid suite.
 - [~] **B8 (SUBSTANTIALLY DONE) — Sybil / free-credit hard rules.** Done:
   canonical provider identity uniqueness, per-key rate limits, a finite welcome
   campaign budget, verified-Google gating for welcome plus daily baseline, and
@@ -177,20 +179,30 @@ on). These are hard gates, not suggestions:
 - Core strict-SIWE tests cover cross-domain rejection, exact-message matching,
   non-burning invalid attempts, and single-use replay rejection. The Console
   client signs the Core-issued message verbatim.
+- Charging now has `off | allowlist | on` rollout modes. Account/service cohorts
+  can be selected and optionally narrowed to exact model IDs.
+- A read-only monitor checks purchased-balance/ledger equality, negative
+  balances, invalid reservation splits, and aging holds. Redacted, rate-limited
+  Discord alerts cover signup, deposits, reservations, settlement, sweepers,
+  invariants, HTTP 500s, and rate limiting.
 - Global charging remains off until production deploy order, price approval,
-  top-up path, monitoring, and a bounded canary are complete.
+  funding UX, and the allowlisted canary in
+  `deploy/DEMAND_BILLING_RUNBOOK.md` are complete.
 
-**Recommended build order:** B1+B6+B5 (+ tests) → B4 (universal metering) →
-B2+B3 (scoped keys + signed bridge identity) → B7 → B8.
+**Remaining launch order:** deploy Core dark → deploy strict-SIWE Console →
+verify Google/wallet account continuity → run one funded allowlisted canary →
+approve price pegs and funding UX → consider broad mode.
 
-The single most security-sensitive new piece is the **identity bridge** for chat
-(trusting a caller-supplied user header). Please focus there.
+The most security-sensitive remaining integration is frontend identity
+delegation: Core must verify global Google/SIWE proof itself, while service
+principals may delegate only their own namespaced application subjects.
 
 ---
 
-## 1. What is BUILT today (shipped dark)
+## 1. What is BUILT today (release candidate, still dark)
 
-All in `system-core/grid_api`, deployed to prod, gated OFF.
+All in `grid-core/grid_api`; production deployment state must be checked against
+the immutable release SHA rather than inferred from this document.
 
 - **Credit ledger** (`services/credits.py`, `v2/schema.py`):
   - `grid_credits(account_id PK, balance_micro BIGINT, updated)` — balance cache.
@@ -201,19 +213,19 @@ All in `system-core/grid_api`, deployed to prod, gated OFF.
     IntegrityError → treated as "already applied"). `debit()` is
     **overdraft-safe + race-safe** via a conditional `UPDATE … WHERE balance >=
     amount` (rowcount 0 ⇒ insufficient, ledger insert rolled back).
-- **Pricing** (`services/pricing.py`): USD-native, "half the cheapest
-  competitor", per-model; `quote_text/image/video` → micro-USD.
+- **Pricing** (`services/pricing.py`): USD-native, per model and modality;
+  `quote_text/image/video/audio/3d` returns integer micro-USD. Some launch pegs
+  remain provisional pending measured worker economics.
 - **Split knobs** (`services/economics.py`): protocol/sentinel/worker split (bps),
   worker USDC/AIPG payout split, AIPG-payment bonus, buyback cap — all integer
   bps, splits sum to the whole (no dust). Currently config-of-record, not yet
   consumed by payout.
-- **Request-path metering** (`routers/openai.py::_meter_charge` →
-  `credits.charge_request`): called once per chat completion (stream +
-  non-stream). Returns `free | legacy | dry_run | ok | already | insufficient`.
-  **In dry-run it logs `would_charge` and returns; never debits/blocks.**
-- **Accounts/identity**: `/v1/accounts/session` (internal-token find-or-create +
-  per-user key), per-account API keys, `/v1/account`, `/v1/account/workers`.
-  Console uses this end-to-end.
+- **Request-path metering**: all text and media submission paths call
+  `authorize_request` or `authorize_media` before dispatch. Selected requests
+  write durable holds; non-selected requests remain dry-run.
+- **Accounts/identity**: canonical identities, strict Core-issued SIWE
+  challenges, Google exchange, scoped per-account keys, and bounded service
+  principals. The internal-token session endpoint is retired by default.
 
 **Built ship-dark / migrating:** durable promotional grants, reduced daily free
 credit, three-pocket reserve/reconcile, canonical identities and merge aliases,
@@ -223,45 +235,29 @@ x402, chat conversion UX, and developer revenue-share.
 
 ---
 
-## 2. The identity keystone — and its threat model (review this hardest)
+## 2. The identity keystone — and its threat model
 
-**Problem.** The chat (Onyx fork) currently calls the grid with **one shared
-`AIPG_GRID_API_KEY`** configured as its LLM provider. The grid therefore sees
-*all* chat traffic as a single account — per-user metering/credits/limits are
-impossible as-is.
+Global identity authority belongs to Core. Google tokens are verified against
+an allowlisted service audience, and wallet login signs an exact Core-issued
+EIP-4361 message with a single-use nonce. Both resolve to a canonical Grid
+account and produce short-lived native user tokens.
 
-**RESOLVED (post-audit): signed user assertions, not a raw header.** The earlier
-"trusted `X-Grid-User` header" idea is **superseded** (it also contradicted
-`GRID_ECONOMICS.md`, which proposed per-user keys). Adopted model = **B2 + B3**:
-the chat authenticates with a **scoped bridge key** (`account.read` +
-`inference.submit` + `identity.assert` only) and sends a **short-lived signed assertion**
-(`iss/sub/aud/exp/nonce`) identifying the end user; the grid verifies the
-signature and meters/attributes to that user. No raw-header trust; the bridge
-key cannot mint keys, change payout wallets, or manage workers. The original
-header proposal is kept below only as the rejected baseline / threat reference.
+First-party backends authenticate with a scoped service key. They may exchange
+only a namespaced application subject (for example `gallery:<local-id>`) and are
+bounded by per-request and daily monetary ceilings. A service key cannot assert
+an arbitrary global Google subject or wallet and cannot manage the delegated
+user's account.
 
-**Rejected baseline — trusted-caller + user header.** The chat keeps its shared key
-but passes the signed-in user's identity per call (`X-Grid-User: <onyx-user-id>`).
-The grid resolves that to a grid account and meters/enforces against it.
+**Threat model:**
 
-**Threat model (the crux):**
-- **Spoofing / cross-user billing.** If *any* caller could set `X-Grid-User`,
-  they could bill other users or evade their own limits. **Mitigation
-  (mandatory):** the header is honored **only** when the request is authenticated
-  by a key explicitly flagged as a *trusted front-end* key — never by ordinary
-  user/API keys. Ordinary keys ignore the header and bill themselves. **Auditor:
-  verify there is no path where an untrusted key's `X-Grid-User` is honored.**
-- **Shared-key blast radius.** The chat's shared key becomes a high-value secret
-  (it can act on behalf of any user). Requires: secret hygiene, rotation, and
-  scoping (trusted-front-end keys should be able to *meter as a user* but not,
-  e.g., mint keys or change payout wallets for that user).
-- **Honest-but-curious chat.** We trust our own front-end to assert the right
-  user. Acceptable for first-party surfaces; **not** a model we'd extend to
-  third parties (they get their own per-account keys instead).
-- **Alternative considered:** provision a real grid key per chat user and thread
-  it through Onyx's LLM call path. Stronger isolation, much more invasive to
-  Onyx (one-key-per-provider model). We chose the header approach for first-party
-  surfaces; auditor input welcome on whether the isolation tradeoff is acceptable.
+- A stolen service key can spend only within its configured ceilings, but it can
+  impersonate that service's local subjects. Rotate it and audit service events.
+- A frontend must not send raw email, wallet, or account IDs as billing
+  authority. Core accepts only its verified proof/token formats.
+- Linking service, Google, and wallet identities must require proof of both
+  sides and must conserve balances through canonical account merges.
+- Long-lived service credentials stay server-side. Browsers receive only
+  short-lived user tokens and never the service key.
 
 ---
 
@@ -309,9 +305,8 @@ The grid resolves that to a grid account and meters/enforces against it.
    (claw back credits? go negative? freeze?).
 8. **Rounding / FX.** All integer micro-USD; swaps introduce slippage. Confirm no
    rounding path lets value be created or destroyed across credit↔debit↔payout.
-9. **Dry-run → live cutover.** The flip is a single env flag. What's the rollback
-   if pricing/metering is wrong under real traffic? (We've been observing dry-run
-   logs against prod traffic first.)
+9. **Dry-run → live cutover.** Review the `off → allowlist → on` policy, cohort
+   matching, kill switch, existing-hold behavior, and required canary evidence.
 10. **Supply-side coupling.** Worker payouts (separate settlement docs) are the
     other half; confirm demand-side revenue and supply-side payout can't be
     conflated or double-counted.
@@ -332,16 +327,16 @@ stake/slash is the load-bearing token utility. Full detail in
 
 ## 6. Open questions for the auditor
 
-- Is the **trusted-header** identity model acceptable for first-party front-ends,
-  or do you require per-user keys / signed user assertions even there?
+- Are Core-verified Google/SIWE plus bounded, namespaced service delegation
+  sufficient for every first-party surface?
 - Sybil/abuse controls for **free credits** — minimum bar before going live?
 - **Refund/chargeback** policy for Stripe and its credit-clawback semantics.
 - **AIPG pricing** on a thin pool — required TWAP window + manipulation bounds,
   or should AIPG deposits be disabled until liquidity deepens?
-- Cutover gating — what evidence from dry-run would you require before
-  `GRID_CHARGING_ENABLED=1`?
-- Key scoping — should "trusted front-end" be a new key class with a restricted
-  capability set (meter-as-user only)?
+- Cutover gating — what allowlisted canary evidence is required before
+  `GRID_CHARGING_MODE=on`?
+- Are current service-client scopes and monetary ceilings narrow enough for each
+  frontend's actual authority?
 
 ---
 

--- a/grid_api/AGENTS.md
+++ b/grid_api/AGENTS.md
@@ -15,8 +15,9 @@ chain sync, and settlement scaffolding. Entry point: `main.py`.
 - `models/` - Pydantic request/response models for OpenAI-compatible requests
   and worker structures.
 - `abis/` / `_abi.py` - local contract ABI loaders used by background sync.
-- `main.py` - lifecycle: DB/Redis init, stale-job reclaimer, recipe sync loop,
-  router registration, and root health metadata.
+- `main.py` - lifecycle: DB/Redis init, stale-job reclaimer, reservation and
+  billing invariant monitors, operator alerts, recipe sync, router registration,
+  and root health metadata.
 
 ## Local Contracts
 

--- a/grid_api/config.py
+++ b/grid_api/config.py
@@ -3,10 +3,13 @@
 
 from functools import lru_cache
 
-from pydantic_settings import BaseSettings
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class GridSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
     # PostgreSQL — reads the same env vars as the Flask app
     postgres_user: str = "postgres"
     postgres_pass: str = "changeme"
@@ -47,9 +50,11 @@ class GridSettings(BaseSettings):
     )
     worker_enrollment_ttl_seconds: int = 900
 
-    class Config:
-        env_file = ".env"
-        extra = "ignore"
+    # Best-effort operator alerts. The webhook is a production secret and must
+    # never be committed, logged, or returned by an API.
+    grid_alert_discord_webhook: SecretStr | None = None
+    grid_alert_queue_size: int = 256
+    grid_alert_dedupe_seconds: int = 300
 
     @property
     def async_database_url(self) -> str:

--- a/grid_api/main.py
+++ b/grid_api/main.py
@@ -63,6 +63,15 @@ async def _stale_job_reclaimer():
                 logger.info(f"Reclaimed {reclaimed} stale jobs")
         except Exception as e:
             logger.error(f"Stale job reclaimer error: {e}")
+            from .services import alerts
+
+            alerts.emit(
+                "stale_job_reclaimer_failed",
+                "critical",
+                "The background queue reclaimer failed.",
+                fields={"error_type": type(e).__name__},
+                dedupe_key="stale-job-reclaimer-failed",
+            )
         await asyncio.sleep(60)  # Check every minute
 
 
@@ -82,6 +91,15 @@ async def _reservation_sweeper():
             await sweep_stale_spends(older_than_seconds=stale)
         except Exception as e:
             logger.error(f"Reservation sweeper error: {e}")
+            from .services import alerts
+
+            alerts.emit(
+                "reservation_sweeper_failed",
+                "critical",
+                "The stale monetary-hold recovery loop failed.",
+                fields={"error_type": type(e).__name__},
+                dedupe_key="reservation-sweeper-failed",
+            )
         await asyncio.sleep(interval)
 
 
@@ -100,13 +118,71 @@ async def _recipe_sync_loop():
         await asyncio.sleep(interval)
 
 
+async def _billing_monitor():
+    """Periodically prove the cached purchased balance matches its ledger."""
+    import os
+
+    from .services import alerts
+    from .services.credits import billing_health
+
+    interval = max(60, int(os.getenv("GRID_BILLING_MONITOR_SECONDS", "300") or 300))
+    held_warning = int(os.getenv("GRID_BILLING_HELD_WARNING_SECONDS", "900") or 900)
+    while True:
+        try:
+            health = await billing_health(held_warning_seconds=held_warning)
+            if not health["ok"]:
+                alerts.emit(
+                    "billing_invariant_failed",
+                    "critical",
+                    "The purchased-credit cache no longer matches its append-only ledger.",
+                    fields=health,
+                    dedupe_key="billing-invariant-failed",
+                )
+            if health["stale_held"]:
+                alerts.emit(
+                    "billing_holds_aging",
+                    "warning",
+                    "Monetary reservations are still held beyond the warning threshold.",
+                    fields={
+                        "held_count": health["stale_held"],
+                        "warning_age_seconds": held_warning,
+                    },
+                    dedupe_key="billing-holds-aging",
+                )
+        except Exception as exc:
+            logger.error("Billing invariant monitor error: %s", exc)
+            alerts.emit(
+                "billing_monitor_failed",
+                "critical",
+                "The read-only billing invariant monitor failed.",
+                fields={"error_type": type(exc).__name__},
+                dedupe_key="billing-monitor-failed",
+            )
+        await asyncio.sleep(interval)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup / shutdown lifecycle."""
+    from .services import alerts
+
     logger.info("Starting Grid Streaming API...")
-    await init_database()
-    await init_redis()
-    await init_p2p()  # Initialize P2P (no-op if disabled)
+    await alerts.start()
+    try:
+        await init_database()
+        await init_redis()
+        await init_p2p()  # Initialize P2P (no-op if disabled)
+    except Exception as exc:
+        alerts.emit(
+            "core_startup_failed",
+            "critical",
+            "Grid Core failed during dependency initialization.",
+            fields={"error_type": type(exc).__name__},
+            dedupe_key="core-startup-failed",
+        )
+        await alerts.flush()
+        await alerts.stop()
+        raise
     reclaimer = asyncio.create_task(_stale_job_reclaimer())
     # Media recipes: load curated local recipes now (servable immediately), then
     # refresh from RecipeVault on an interval (no-op until BASE_RPC/addr configured).
@@ -122,20 +198,36 @@ async def lifespan(app: FastAPI):
     _styles.load_local_styles(os.path.join(_base, "styles"))
     recipe_sync = asyncio.create_task(_recipe_sync_loop())
     sweeper = asyncio.create_task(_reservation_sweeper())
+    billing_monitor = asyncio.create_task(_billing_monitor())
     # Verification probes ("validator zero") — dormant unless GRID_PROBE_ENABLED;
     # even ON it only records evidence (no reward/slash). See VERIFICATION_PROBES.md.
     from .services import probe as _probe
     prober = asyncio.create_task(_probe.probe_loop())
+    from .services import credits as _credits
+    alerts.emit(
+        "core_started",
+        "success",
+        "Grid Core started and its background safety loops are running.",
+        fields={
+            "charging_mode": _credits.charging_mode(),
+            "charging_accounts": len(_credits.CHARGING_ALLOW_ACCOUNTS),
+            "charging_services": len(_credits.CHARGING_ALLOW_SERVICES),
+            "charging_models": len(_credits.CHARGING_ALLOW_MODELS),
+        },
+        dedupe_key="core-started",
+    )
     logger.info("Grid Streaming API ready.")
     yield
     logger.info("Shutting down Grid Streaming API...")
     reclaimer.cancel()
     recipe_sync.cancel()
     sweeper.cancel()
+    billing_monitor.cancel()
     prober.cancel()
     await close_p2p()  # Shutdown P2P
     await close_redis()
     await close_database()
+    await alerts.stop()
 
 
 app = FastAPI(
@@ -148,8 +240,38 @@ app = FastAPI(
 app.state.limiter = limiter
 
 
+@app.middleware("http")
+async def alert_unhandled_http_failure(request: Request, call_next):
+    try:
+        return await call_next(request)
+    except Exception as exc:
+        from .services import alerts
+
+        alerts.emit(
+            "unhandled_http_failure",
+            "critical",
+            "A Core HTTP request failed with an unhandled server exception.",
+            fields={
+                "method": request.method,
+                "path": request.url.path,
+                "error_type": type(exc).__name__,
+            },
+            dedupe_key=f"http-500:{request.method}:{request.url.path}:{type(exc).__name__}",
+        )
+        raise
+
+
 @app.exception_handler(RateLimitExceeded)
 async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
+    from .services import alerts
+
+    alerts.emit(
+        "http_rate_limited",
+        "warning",
+        "A public API route is being rate limited.",
+        fields={"method": request.method, "path": request.url.path},
+        dedupe_key=f"http-429:{request.method}:{request.url.path}",
+    )
     return JSONResponse(
         status_code=429,
         content={"error": {"message": "Rate limit exceeded. Please slow down.", "type": "rate_limit_error"}},

--- a/grid_api/routers/AGENTS.md
+++ b/grid_api/routers/AGENTS.md
@@ -25,7 +25,7 @@ transport, accounts, stats, health/metrics.
 - `worker_ws.py` - `/v1/workers/ws`: registration + dispatch + health/eviction + streaming.
   **God-file (~1.1K LOC); split target = registration / dispatch / health / stream.** Highest
   bug history (eviction cascade, idle-redelivery) - change carefully, add tests.
-- `accounts.py` - native Google/SIWE auth, bounded service exchange, and
+- `accounts.py` - native Google/strict EIP-4361 SIWE auth, bounded service exchange, and
   default-off legacy dashboard/internal session creation,
   account profile (incl. resolved `payout{asset, aipg_bps, active, live_asset}`),
   payout wallet + `POST /v1/account/payout-preference` (both SESSION-gated),
@@ -42,6 +42,10 @@ transport, accounts, stats, health/metrics.
   tokens are verified at `/v1/auth/google/exchange`; `/v1/auth/service/bind`
   binds an app subject after recent Google/SIWE proof. `/v1/accounts/bridges`
   bootstraps a bounded service client only when separately enabled.
+  Wallet login uses `/v1/accounts/wallet/challenge`; the signed message binds
+  wallet, allowlisted frontend domain/URI, Base chain id, issue/expiry time, and
+  a single-use nonce. `/wallet/nonce` remains for authenticated wallet-link
+  proofs, not for minting a login session.
 - `stats.py` - `GET /v1/workers`, progress polling, recipe-aware model status
   (raw worker checkpoints plus executable recipe-backed public model names), usage totals,
   model stats, wallet earnings, `GET /v1/payouts/public` (aggregate payout

--- a/grid_api/routers/_passthrough.py
+++ b/grid_api/routers/_passthrough.py
@@ -270,8 +270,6 @@ async def authorize_passthrough(user: dict, model: str, api_format: str,
     (charging off) it's a no-op: ok, reserved=0. The caller shapes its own
     402 from `{ok: False, reason}` so each endpoint keeps its native error body."""
     prompt_toks = den.count_tokens(extract_prompt_text(api_format, raw_request))
-    if not credits.CHARGING_ENABLED:
-        return {"ok": True, "reserved": 0, "prompt_toks": prompt_toks, "status": "dry_run"}
     auth = dict(await credits.authorize_request(
         user, model, prompt_toks, max_len, job_id, record_reservation=True))
     auth["prompt_toks"] = prompt_toks
@@ -283,7 +281,7 @@ async def _observe_dry_passthrough(user, model, prompt_toks, completion_toks, jo
     settlement is durable + authoritative in the worker-WS handler
     (credits.settle_job) — doing it here too would double-settle and depend on the
     client staying connected. Never breaks a response."""
-    if credits.CHARGING_ENABLED:
+    if credits.charging_enabled_for(user, model):
         return
     try:
         await credits.charge_request(

--- a/grid_api/routers/accounts.py
+++ b/grid_api/routers/accounts.py
@@ -1319,7 +1319,8 @@ async def get_credits(
     semantics), gated on GRID_FREE_SPENDABLE_LIVE. `free.active` below reflects
     that flag: false → free is display-only and total_spendable = paid only;
     true → charges draw free-first and total_spendable includes it.
-    charging_enabled is the overall live gate (dark = nothing is charged).
+    charging_enabled is the effective gate for this account. charging_mode
+    exposes the operator rollout state without exposing the allowlist.
     """
     user = await _require_v2(
         apikey,
@@ -1372,7 +1373,8 @@ async def get_credits(
         # promo + daily free + paid after all shadow gates are enabled.
         "total_preview_micro": total,
         "total_preview_usd": usd(total),
-        "charging_enabled": credits_svc.CHARGING_ENABLED,  # false while dark
+        "charging_enabled": credits_svc.charging_enabled_for(user),
+        "charging_mode": credits_svc.charging_mode(),
     }
 
 

--- a/grid_api/routers/accounts.py
+++ b/grid_api/routers/accounts.py
@@ -12,11 +12,14 @@ Key management (list/issue/revoke) authenticates with any active key on the
 account. Plaintext keys are returned exactly once and never stored.
 """
 
+import json
 import logging
 import os
 import re
 import uuid as uuid_mod
+from datetime import datetime, timedelta, timezone
 from typing import Optional
+from urllib.parse import urlsplit
 
 import sqlalchemy as sa
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -46,12 +49,30 @@ _NONCE_TTL = 300
 _NONCE_PREFIX = "grid:siwe_nonce:"
 
 
-async def _nonce_issue() -> str:
+async def _nonce_issue(value: dict | None = None, *, nonce: str | None = None) -> str:
     from ..redis_client import get_redis
 
-    nonce = uuid_mod.uuid4().hex
-    await get_redis().set(f"{_NONCE_PREFIX}{nonce}", "1", ex=_NONCE_TTL)
+    nonce = nonce or uuid_mod.uuid4().hex
+    stored = json.dumps(value, separators=(",", ":"), sort_keys=True) if value else "1"
+    await get_redis().set(f"{_NONCE_PREFIX}{nonce}", stored, ex=_NONCE_TTL)
     return nonce
+
+
+async def _nonce_peek(nonce: str) -> dict | None:
+    if not nonce:
+        return None
+    from ..redis_client import get_redis
+
+    raw = await get_redis().get(f"{_NONCE_PREFIX}{nonce}")
+    if not raw:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        return {"kind": "legacy"}
+    return value if isinstance(value, dict) else {"kind": "legacy"}
 
 
 async def _nonce_consume(nonce: str) -> bool:
@@ -79,6 +100,13 @@ class WalletVerifyForm(BaseModel):
     signature: str
     address: str
     username: Optional[str] = None
+
+
+class WalletChallengeForm(BaseModel):
+    address: str
+    domain: str = Field(min_length=1, max_length=255)
+    uri: str = Field(min_length=1, max_length=2048)
+    chain_id: int = 8453
 
 
 class WalletLinkForm(BaseModel):
@@ -159,6 +187,80 @@ async def wallet_nonce(request: Request):
     return {"nonce": await _nonce_issue()}
 
 
+def _allowed_siwe_domain(domain: str, uri: str) -> bool:
+    domain = domain.strip().lower()
+    parsed = urlsplit(uri)
+    if not parsed.hostname or parsed.netloc.lower() != domain:
+        return False
+    local = parsed.hostname.lower() in {"localhost", "127.0.0.1", "::1"}
+    if parsed.scheme != "https" and not (local and parsed.scheme == "http"):
+        return False
+    configured = os.getenv(
+        "GRID_SIWE_ALLOWED_DOMAINS",
+        "console.aipowergrid.io,aipg.art,aipg.chat,aipg.music",
+    )
+    allowed = {item.strip().lower() for item in configured.split(",") if item.strip()}
+    return domain in allowed or local
+
+
+def _siwe_message(*, domain: str, address: str, uri: str, chain_id: int,
+                  nonce: str, issued_at: str, expiration_time: str) -> str:
+    return (
+        f"{domain} wants you to sign in with your Ethereum account:\n"
+        f"{address}\n\n"
+        "Sign in to AI Power Grid.\n\n"
+        f"URI: {uri}\n"
+        "Version: 1\n"
+        f"Chain ID: {chain_id}\n"
+        f"Nonce: {nonce}\n"
+        f"Issued At: {issued_at}\n"
+        f"Expiration Time: {expiration_time}"
+    )
+
+
+@router.post("/v1/accounts/wallet/challenge")
+@limiter.limit("30/minute")
+async def wallet_challenge(request: Request, form: WalletChallengeForm):
+    """Issue a domain-, address-, URI-, chain-, and time-bound EIP-4361 message."""
+    if not accounts_svc.is_valid_eth_address(form.address):
+        raise HTTPException(422, detail="Invalid wallet address")
+    if form.chain_id != 8453:
+        raise HTTPException(422, detail="Wallet sign-in requires Base chain ID 8453")
+    if not _allowed_siwe_domain(form.domain, form.uri):
+        raise HTTPException(422, detail="Wallet sign-in origin is not allowed")
+
+    nonce = uuid_mod.uuid4().hex
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    issued_at = now.isoformat().replace("+00:00", "Z")
+    expiration_time = (now + timedelta(seconds=_NONCE_TTL)).isoformat().replace("+00:00", "Z")
+    message = _siwe_message(
+        domain=form.domain.strip().lower(),
+        address=form.address,
+        uri=form.uri,
+        chain_id=form.chain_id,
+        nonce=nonce,
+        issued_at=issued_at,
+        expiration_time=expiration_time,
+    )
+    await _nonce_issue(
+        {
+            "kind": "siwe",
+            "address": form.address.lower(),
+            "domain": form.domain.strip().lower(),
+            "uri": form.uri,
+            "chain_id": form.chain_id,
+            "message": message,
+        },
+        nonce=nonce,
+    )
+    return {
+        "nonce": nonce,
+        "message": message,
+        "expires_in": _NONCE_TTL,
+        "chain_id": form.chain_id,
+    }
+
+
 @router.post("/v1/accounts/wallet/verify")
 @limiter.limit("10/minute")
 async def wallet_verify(request: Request, form: WalletVerifyForm):
@@ -171,16 +273,18 @@ async def wallet_verify(request: Request, form: WalletVerifyForm):
 
     m = re.search(r"Nonce: ([0-9a-fA-F]+)", form.message)
     nonce = m.group(1) if m else None
-    if not await _nonce_consume(nonce):
+    challenge = await _nonce_peek(nonce)
+    if not challenge:
         raise HTTPException(401, detail="Invalid or expired nonce. Please retry.")
 
-    # Bind the signed message to the EXACT canonical sign-in text (the client
-    # signs this verbatim). Without this, a signature the victim made elsewhere
-    # (another dApp's login, a token approval) that merely contains our nonce
-    # string could be replayed here to mint their session. Requiring the exact
-    # message eliminates that replay class. (Follow-up: upgrade to full EIP-4361
-    # with domain/issued-at when the console/gallery clients migrate.)
-    expected_message = f"Sign in to AIPG Grid\n\nNonce: {nonce}"
+    if challenge.get("kind") == "siwe":
+        expected_message = challenge.get("message")
+        if challenge.get("address") != form.address.lower():
+            raise HTTPException(401, detail="Sign-in challenge belongs to a different wallet.")
+    elif os.getenv("GRID_LEGACY_SIWE_VERIFY_ENABLED", "0").lower() in {"1", "true", "yes", "on"}:
+        expected_message = f"Sign in to AIPG Grid\n\nNonce: {nonce}"
+    else:
+        raise HTTPException(401, detail="Legacy wallet sign-in is disabled; request a SIWE challenge.")
     if form.message != expected_message:
         raise HTTPException(401, detail="Unexpected sign-in message; refusing to verify.")
 
@@ -193,6 +297,8 @@ async def wallet_verify(request: Request, form: WalletVerifyForm):
         raise HTTPException(401, detail="Signature verification failed.")
     if recovered.lower() != form.address.lower():
         raise HTTPException(401, detail="Signature does not match the address.")
+    if not await _nonce_consume(nonce):
+        raise HTTPException(401, detail="Sign-in challenge was already used. Please retry.")
 
     wallet = recovered.lower()
     account = await accounts_svc.get_account_by_wallet(wallet)

--- a/grid_api/routers/openai.py
+++ b/grid_api/routers/openai.py
@@ -51,15 +51,14 @@ logger = logging.getLogger("grid_api.openai")
 
 
 async def _observe_dry(user, model, prompt_tokens, completion_tokens, job_id):
-    """Dry-run observability ONLY (GRID_CHARGING_ENABLED=0): log the would-charge
-    against grid-counted usage so we can watch pricing on real traffic.
+    """Log would-charge usage when this request is outside the charging cohort.
 
     LIVE settlement is NOT done here — it's durable and authoritative in the
     worker-WS handler (credits.settle_job), which reaches a terminal state for
     every job whether or not the client stayed connected. Doing it here too would
     double-settle and depend on the client staying connected. Never breaks a
     response (already sent), so errors are swallowed."""
-    if credits.CHARGING_ENABLED:
+    if credits.charging_enabled_for(user, model):
         return
     try:
         await credits.charge_request(
@@ -417,13 +416,12 @@ async def _handle_chat_completions(request: ChatCompletionRequest, apikey: str,
                             detail=f"Too many concurrent requests (limit {TEXT_CONCURRENCY}). Retry shortly.")
     inflight_held = bool(aid)
     try:
-        if credits.CHARGING_ENABLED:
-            auth = await credits.authorize_request(
-                user, model, prompt_toks, request.max_tokens, job_id,
-                record_reservation=True,
-            )
-            if not auth["ok"]:
-                raise HTTPException(status_code=402, detail=auth.get("reason", "payment required"))
+        auth = await credits.authorize_request(
+            user, model, prompt_toks, request.max_tokens, job_id,
+            record_reservation=True,
+        )
+        if not auth["ok"]:
+            raise HTTPException(status_code=402, detail=auth.get("reason", "payment required"))
 
         # Submit to the Grid Redis Stream for workers.
         # If dispatch itself fails the job never runs, so the held reservation must be

--- a/grid_api/routers/tests/test_audio_contract.py
+++ b/grid_api/routers/tests/test_audio_contract.py
@@ -53,7 +53,7 @@ def test_audio_request_is_strict_and_bounded():
 
 
 def test_audio_pricing_and_den_are_duration_based():
-    assert pricing.quote_audio(audio.DEFAULT_AUDIO_MODEL, 30) == 120_000
+    assert pricing.quote_audio(audio.DEFAULT_AUDIO_MODEL, 30) == 6_000
     assert den.calculate_media_den("audio", 1, 1, n=1, seconds=30) == 1.8
     assert den.calculate_media_den("audio", 4096, 4096, n=1, seconds=30) == 1.8
 

--- a/grid_api/routers/tests/test_siwe_auth.py
+++ b/grid_api/routers/tests/test_siwe_auth.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2026 AI Power Grid
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import json
+import uuid
+
+import pytest
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from grid_api.routers import accounts
+from grid_api.services import user_tokens
+
+
+class FakeRedis:
+    def __init__(self):
+        self.values = {}
+
+    async def set(self, key, value, ex=None):
+        self.values[key] = value
+        return True
+
+    async def get(self, key):
+        return self.values.get(key)
+
+    async def getdel(self, key):
+        return self.values.pop(key, None)
+
+
+def _request() -> Request:
+    return Request({"type": "http", "method": "POST", "path": "/", "headers": []})
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    redis = FakeRedis()
+    monkeypatch.setattr("grid_api.redis_client.get_redis", lambda: redis)
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_siwe_challenge_binds_origin_wallet_chain_and_time(fake_redis):
+    wallet = Account.create()
+    response = await accounts.wallet_challenge(
+        _request(),
+        accounts.WalletChallengeForm(
+            address=wallet.address,
+            domain="console.aipowergrid.io",
+            uri="https://console.aipowergrid.io/",
+            chain_id=8453,
+        ),
+    )
+    message = response["message"]
+    assert message.startswith(
+        f"console.aipowergrid.io wants you to sign in with your Ethereum account:\n{wallet.address}"
+    )
+    assert "URI: https://console.aipowergrid.io/" in message
+    assert "Chain ID: 8453" in message
+    assert f"Nonce: {response['nonce']}" in message
+    assert "Issued At:" in message and "Expiration Time:" in message
+    stored = json.loads(fake_redis.values[f"{accounts._NONCE_PREFIX}{response['nonce']}"])
+    assert stored["message"] == message
+    assert stored["address"] == wallet.address.lower()
+
+
+@pytest.mark.asyncio
+async def test_siwe_challenge_rejects_cross_domain_uri(fake_redis):
+    wallet = Account.create()
+    with pytest.raises(HTTPException) as exc:
+        await accounts.wallet_challenge(
+            _request(),
+            accounts.WalletChallengeForm(
+                address=wallet.address,
+                domain="console.aipowergrid.io",
+                uri="https://evil.example/",
+            ),
+        )
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_wallet_verify_requires_exact_single_use_siwe(fake_redis, monkeypatch):
+    wallet = Account.create()
+    response = await accounts.wallet_challenge(
+        _request(),
+        accounts.WalletChallengeForm(
+            address=wallet.address,
+            domain="console.aipowergrid.io",
+            uri="https://console.aipowergrid.io/",
+        ),
+    )
+
+    async def existing_account(_wallet):
+        return {"id": uuid.uuid4(), "username": "wallet-user"}
+
+    monkeypatch.setattr(accounts.accounts_svc, "get_account_by_wallet", existing_account)
+    monkeypatch.setattr(user_tokens, "issue", lambda *_args, **_kwargs: "grid-token")
+
+    signature = Account.sign_message(
+        encode_defunct(text=response["message"]),
+        wallet.key,
+    ).signature.hex()
+    bad = accounts.WalletVerifyForm(
+        message=response["message"] + "\n",
+        signature=signature,
+        address=wallet.address,
+    )
+    with pytest.raises(HTTPException):
+        await accounts.wallet_verify(_request(), bad)
+
+    # A malformed verify attempt does not burn the user's challenge.
+    good = accounts.WalletVerifyForm(
+        message=response["message"],
+        signature=signature,
+        address=wallet.address,
+    )
+    verified = await accounts.wallet_verify(_request(), good)
+    assert verified["access_token"] == "grid-token"
+    assert verified["wallet"] == wallet.address.lower()
+
+    with pytest.raises(HTTPException) as replay:
+        await accounts.wallet_verify(_request(), good)
+    assert replay.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_legacy_generic_signin_is_disabled_by_default(fake_redis, monkeypatch):
+    monkeypatch.delenv("GRID_LEGACY_SIWE_VERIFY_ENABLED", raising=False)
+    wallet = Account.create()
+    nonce = await accounts._nonce_issue()
+    message = f"Sign in to AIPG Grid\n\nNonce: {nonce}"
+    signature = Account.sign_message(encode_defunct(text=message), wallet.key).signature.hex()
+    with pytest.raises(HTTPException) as exc:
+        await accounts.wallet_verify(
+            _request(),
+            accounts.WalletVerifyForm(
+                message=message,
+                signature=signature,
+                address=wallet.address,
+            ),
+        )
+    assert exc.value.status_code == 401
+    assert "Legacy wallet sign-in is disabled" in exc.value.detail

--- a/grid_api/services/AGENTS.md
+++ b/grid_api/services/AGENTS.md
@@ -74,9 +74,16 @@ content sanitization, and reward settlement.
 - Service keys remain long-lived backend credentials but cannot manage user
   accounts. Global Google/SIWE proof is verified by Core; app delegation is
   namespaced to one service and receives bounded inference authority.
-- The free request-count quota exempts a direct service key only when both its
-  per-request and daily micro-USD ceilings are positive. Delegated users and
-  unbounded service keys remain in the free-user quota path.
+- The free request-count quota exempts positive purchased-credit accounts and a
+  direct service key only when both its per-request and daily micro-USD ceilings
+  are positive. Promotional/daily-free value, delegated users without purchased
+  credit, and unbounded service keys remain in the free-user quota path.
+- Service ceilings are exposure reservations keyed by job id: reserve before
+  dispatch, reduce to actual text spend on success, and release on 402/no-work
+  terminals. Redis failure stays conservative until the day bucket expires.
+- Price coverage is modality-specific. A model entry with only a video rate is
+  unpriced for image/text, and positive quotes round up to one micro-USD rather
+  than silently becoming free.
 - Text reservations snapshot input/output rates and holder discount at reserve
   time. Never reprice an in-flight job from the current price book.
 - `ledger.py` writes one completion event per job. Settlement and stats depend on

--- a/grid_api/services/AGENTS.md
+++ b/grid_api/services/AGENTS.md
@@ -21,7 +21,8 @@ content sanitization, and reward settlement.
   `identities.py` (verified identities, aliases, and value-conserving merges),
   `user_tokens.py` (Core-issued short-lived sessions), `service_auth.py`
   (bounded service clients + proof exchange), `service_limits.py` (fail-closed
-  request/day ceilings), `assertions.py` (legacy app-only assertions), `economics.py`
+  request/day ceilings), `alerts.py` (redacted, bounded operator event delivery),
+  `assertions.py` (legacy app-only assertions), `economics.py`
   (splits, payout-asset + conversion-fee knobs, `worker_share_bps`),
   `holdings.py` (cached on-chain AIPG balance + Chainlink ETH/USD),
   `deposits.py` (USDC/ETH deposit claims), `model_registry.py` (ModelVault sync).
@@ -84,6 +85,11 @@ content sanitization, and reward settlement.
 - Price coverage is modality-specific. A model entry with only a video rate is
   unpriced for image/text, and positive quotes round up to one micro-USD rather
   than silently becoming free.
+- New monetary holds obey `off | allowlist | on`; an existing durable hold must
+  still settle or refund after the operator disables new charging.
+- Operator alerts are best-effort and data-minimized. Never include prompts,
+  outputs, email addresses, credentials, signatures, raw exceptions, or
+  unredacted identity values in alert fields.
 - Text reservations snapshot input/output rates and holder discount at reserve
   time. Never reprice an in-flight job from the current price book.
 - `ledger.py` writes one completion event per job. Settlement and stats depend on

--- a/grid_api/services/accounts.py
+++ b/grid_api/services/accounts.py
@@ -430,6 +430,27 @@ async def create_account(
         except Exception:
             logger.warning("Welcome grant failed for account %s", account_id, exc_info=True)
     logger.info(f"Account created: {account_id} (wallet={wallet or '-'})")
+    from . import alerts
+
+    provider = (
+        identity_kind
+        or (oauth_kind if oauth_sub else None)
+        or ("wallet" if wallet else None)
+        or ("verified_email" if email and email_verified else None)
+        or "internal"
+    )
+    alerts.emit(
+        "account_created",
+        "success",
+        "A new Grid account was created.",
+        fields={
+            "account": alerts.opaque_id(account_id),
+            "provider": provider,
+            "initial_key": bool(issue_initial_key),
+            "welcome_eligible": bool(grant_verified_welcome and provider == "google"),
+        },
+        dedupe_key=f"account-created:{alerts.opaque_id(account_id)}",
+    )
     return {"id": str(account_id), "username": username, "wallet": wallet}, (plain if issue_initial_key else None)
 
 
@@ -694,6 +715,21 @@ async def create_service_client(
             ),
         )
         await session.commit()
+    from . import alerts
+
+    alerts.emit(
+        "service_client_created",
+        "success",
+        "A bounded frontend or application service principal was provisioned.",
+        fields={
+            "account": alerts.opaque_id(account_id),
+            "service": sid,
+            "provider_count": len(allowed),
+            "per_request_micro": per_request_micro if per_request_micro is not None else "unset",
+            "daily_micro": daily_micro if daily_micro is not None else "unset",
+        },
+        dedupe_key=f"service-created:{sid}",
+    )
     return {"id": sid, "account_id": str(account_id), "name": name}, plain
 
 

--- a/grid_api/services/alerts.py
+++ b/grid_api/services/alerts.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: 2026 AI Power Grid
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Best-effort operational alerts with strict data minimization.
+
+Alerts are never part of a money or authentication transaction. Callers enqueue
+small, pre-classified events; one bounded background worker delivers them to an
+operator-owned Discord webhook. Prompts, responses, credentials, email addresses,
+signatures, and raw exceptions are intentionally unsupported.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import re
+import secrets
+import time
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+import httpx
+
+from ..config import get_settings
+
+logger = logging.getLogger("grid_api.alerts")
+
+_SENTINEL = object()
+_queue: asyncio.Queue | None = None
+_worker_task: asyncio.Task | None = None
+_client: httpx.AsyncClient | None = None
+_last_sent: dict[str, float] = {}
+_suppressed: dict[str, int] = {}
+
+_BLOCKED_FIELD_FRAGMENTS = {
+    "authorization",
+    "cookie",
+    "email",
+    "key",
+    "message",
+    "output",
+    "password",
+    "prompt",
+    "secret",
+    "signature",
+    "token",
+    "webhook",
+}
+_EMAIL_RE = re.compile(r"\b[^@\s]+@[^@\s]+\.[^@\s]+\b")
+_WEBHOOK_RE = re.compile(r"https://(?:canary\.|ptb\.)?discord(?:app)?\.com/api/webhooks/\S+", re.I)
+_BEARER_RE = re.compile(r"\b(?:Bearer\s+)?(?:sk|aipg|grid)[-_][A-Za-z0-9._-]{12,}\b", re.I)
+_COLORS = {
+    "info": 0x4EA1FF,
+    "warning": 0xF5A524,
+    "critical": 0xE5484D,
+    "success": 0x30A46C,
+}
+
+
+def opaque_id(value) -> str:
+    """Stable short identifier safe for operator correlation."""
+    if value in (None, ""):
+        return "-"
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:12]
+
+
+def _safe_text(value, *, limit: int = 240) -> str:
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    text = _WEBHOOK_RE.sub("[redacted-webhook]", text)
+    text = _EMAIL_RE.sub("[redacted-email]", text)
+    text = _BEARER_RE.sub("[redacted-credential]", text)
+    return text[:limit] or "-"
+
+
+def _safe_fields(fields: Mapping | None) -> list[dict[str, object]]:
+    safe = []
+    for raw_name, raw_value in (fields or {}).items():
+        name = str(raw_name).strip().lower().replace(" ", "_")
+        if not name or any(fragment in name for fragment in _BLOCKED_FIELD_FRAGMENTS):
+            continue
+        if raw_value is None:
+            continue
+        safe.append(
+            {
+                "name": _safe_text(name, limit=80),
+                "value": _safe_text(raw_value),
+                "inline": len(str(raw_value)) <= 48,
+            },
+        )
+        if len(safe) == 12:
+            break
+    return safe
+
+
+def build_payload(kind: str, severity: str, summary: str, fields: Mapping | None = None) -> dict:
+    """Build a Discord payload containing only bounded, redacted metadata."""
+    severity = severity if severity in _COLORS else "info"
+    return {
+        "username": "AIPG Grid Operations",
+        "allowed_mentions": {"parse": []},
+        "embeds": [
+            {
+                "title": f"{severity.upper()}: {_safe_text(kind, limit=80)}",
+                "description": _safe_text(summary, limit=500),
+                "color": _COLORS[severity],
+                "fields": _safe_fields(fields),
+                "timestamp": datetime.now(UTC).isoformat(),
+                "footer": {"text": "grid-core"},
+            },
+        ],
+    }
+
+
+def _valid_webhook(url: str) -> bool:
+    parsed = urlparse(url)
+    return (
+        parsed.scheme == "https"
+        and parsed.hostname in {"discord.com", "canary.discord.com", "ptb.discord.com"}
+        and parsed.path.startswith("/api/webhooks/")
+    )
+
+
+def _configured_url() -> str:
+    secret = get_settings().grid_alert_discord_webhook
+    return secret.get_secret_value().strip() if secret else ""
+
+
+async def start() -> None:
+    """Start the delivery worker. Safe and idempotent."""
+    global _queue, _worker_task, _client
+    if _worker_task and not _worker_task.done():
+        return
+    url = _configured_url()
+    if not url:
+        logger.info("Discord operational alerts are disabled")
+        return
+    if not _valid_webhook(url):
+        logger.error("GRID_ALERT_DISCORD_WEBHOOK is not an official Discord webhook; alerts disabled")
+        return
+    settings = get_settings()
+    _queue = asyncio.Queue(maxsize=max(10, settings.grid_alert_queue_size))
+    _client = httpx.AsyncClient(timeout=httpx.Timeout(5.0))
+    _worker_task = asyncio.create_task(_run(url), name="grid-discord-alerts")
+
+
+def emit(
+    kind: str,
+    severity: str,
+    summary: str,
+    *,
+    fields: Mapping | None = None,
+    dedupe_key: str | None = None,
+) -> bool:
+    """Enqueue an alert without waiting. Returns False when disabled or full."""
+    if _queue is None or _worker_task is None or _worker_task.done():
+        return False
+    item = (kind, severity, summary, dict(fields or {}), dedupe_key or kind)
+    try:
+        _queue.put_nowait(item)
+        return True
+    except asyncio.QueueFull:
+        logger.error("Discord alert queue full; dropping event kind=%s", _safe_text(kind, limit=80))
+        return False
+
+
+async def _deliver(url: str, payload: dict) -> bool:
+    client = _client
+    if client is None:
+        logger.error("Discord alert client is not initialized")
+        return False
+    for attempt in range(3):
+        try:
+            response = await client.post(url, json=payload)
+            if response.status_code in {200, 204}:
+                return True
+            if response.status_code == 429:
+                delay = min(float(response.headers.get("retry-after", "1") or 1), 5.0)
+            elif response.status_code >= 500:
+                delay = min(2**attempt, 4)
+            else:
+                logger.error("Discord alert rejected with HTTP %d", response.status_code)
+                return False
+        except (httpx.TimeoutException, httpx.NetworkError):
+            delay = min(2**attempt, 4)
+        if attempt < 2:
+            await asyncio.sleep(delay)
+    logger.error("Discord alert delivery failed after retries")
+    return False
+
+
+async def _claim_distributed(key: str, ttl_seconds: int):
+    """Claim one cross-process delivery window in Redis.
+
+    Returns a release tuple for the winner, ``None`` for another process's
+    duplicate, and ``False`` when Redis is unavailable (local dedupe applies).
+    """
+    if ttl_seconds <= 0:
+        return False
+    try:
+        from ..redis_client import get_redis
+
+        redis = get_redis()
+        redis_key = f"grid:alerts:dedupe:{hashlib.sha256(key.encode()).hexdigest()}"
+        token = secrets.token_hex(16)
+        claimed = await redis.set(redis_key, token, ex=ttl_seconds, nx=True)
+        return (redis, redis_key, token) if claimed else None
+    except Exception:
+        return False
+
+
+async def _release_distributed(claim) -> None:
+    if not claim:
+        return
+    redis, key, token = claim
+    try:
+        await redis.eval(
+            "if redis.call('get', KEYS[1]) == ARGV[1] then "
+            "return redis.call('del', KEYS[1]) else return 0 end",
+            1,
+            key,
+            token,
+        )
+    except Exception:
+        logger.debug("Could not release failed Discord alert dedupe claim", exc_info=True)
+
+
+async def _run(url: str) -> None:
+    settings = get_settings()
+    dedupe_seconds = max(0, settings.grid_alert_dedupe_seconds)
+    queue = _queue
+    if queue is None:
+        logger.error("Discord alert queue is not initialized")
+        return
+    while True:
+        item = await queue.get()
+        try:
+            if item is _SENTINEL:
+                return
+            kind, severity, summary, fields, key = item
+            now = time.monotonic()
+            if dedupe_seconds and now - _last_sent.get(key, 0) < dedupe_seconds:
+                _suppressed[key] = _suppressed.get(key, 0) + 1
+                continue
+            claim = await _claim_distributed(key, dedupe_seconds)
+            if claim is None:
+                _suppressed[key] = _suppressed.get(key, 0) + 1
+                continue
+            suppressed = _suppressed.pop(key, 0)
+            if suppressed:
+                fields["suppressed_since_last"] = suppressed
+            delivered = await _deliver(url, build_payload(kind, severity, summary, fields))
+            if delivered:
+                _last_sent[key] = now
+            else:
+                await _release_distributed(claim)
+            await asyncio.sleep(0.3)
+        except Exception:
+            logger.exception("Discord alert worker failed processing one event")
+        finally:
+            queue.task_done()
+
+
+async def flush(timeout: float = 5.0) -> None:
+    if _queue is None:
+        return
+    try:
+        await asyncio.wait_for(_queue.join(), timeout=timeout)
+    except TimeoutError:
+        logger.warning("Timed out draining Discord alerts")
+
+
+async def stop() -> None:
+    """Drain queued alerts and close the transport."""
+    global _queue, _worker_task, _client
+    if _queue is not None and _worker_task is not None and not _worker_task.done():
+        await flush()
+        await _queue.put(_SENTINEL)
+        await _worker_task
+    if _client is not None:
+        await _client.aclose()
+    _queue = None
+    _worker_task = None
+    _client = None

--- a/grid_api/services/credits.py
+++ b/grid_api/services/credits.py
@@ -1,7 +1,7 @@
-# ⚠️ WIRED-DARK (2026-06-23): the request path (routers/openai.py _meter_charge) now
-# calls charge_request on every completion, but charging is GATED OFF by default
-# (GRID_CHARGING_ENABLED=0) — it only LOGS the would-charge amount and never debits,
-# blocks, or touches the credit tables. Flip the env var to go live. See task #73.
+# WIRED-DARK: every demand path calls this service, but
+# GRID_CHARGING_MODE=off only records dry-run observations. Use allowlist for a
+# bounded canary before considering on. The legacy GRID_CHARGING_ENABLED switch
+# is compatibility-only when GRID_CHARGING_MODE is absent.
 
 # SPDX-FileCopyrightText: 2026 AI Power Grid
 # SPDX-License-Identifier: AGPL-3.0-or-later
@@ -19,9 +19,9 @@ covers the charge) and idempotent (unique `ref` per charge — a retried request
 can't double-bill). `credit` (top-up) is idempotent on `ref` too, so a re-seen
 deposit / Stripe event can't double-credit.
 
-Charging is OFF by default (`GRID_CHARGING_ENABLED`): until you flip it on,
-`charge_request` only LOGS what it would bill and never debits or blocks — so
-this can ship dark and be observed against real traffic first.
+Charging is OFF by default (`GRID_CHARGING_MODE=off`): requests only log what
+they would bill and never debit or block. `allowlist` enables a bounded account
+or service cohort; `on` enables all authenticated demand.
 """
 
 import datetime as _dt
@@ -45,6 +45,67 @@ from . import service_limits
 logger = logging.getLogger("grid_api.credits")
 
 CHARGING_ENABLED = os.getenv("GRID_CHARGING_ENABLED", "0").lower() in ("1", "true", "yes")
+_CHARGING_MODE_ENV = os.getenv("GRID_CHARGING_MODE", "").strip().lower()
+_CHARGING_MODES = {"off", "allowlist", "on"}
+
+
+def _csv_env(name: str) -> frozenset[str]:
+    return frozenset(
+        item.strip().lower()
+        for item in os.getenv(name, "").split(",")
+        if item.strip()
+    )
+
+
+CHARGING_ALLOW_ACCOUNTS = _csv_env("GRID_CHARGING_ALLOW_ACCOUNTS")
+CHARGING_ALLOW_SERVICES = _csv_env("GRID_CHARGING_ALLOW_SERVICES")
+CHARGING_ALLOW_MODELS = _csv_env("GRID_CHARGING_ALLOW_MODELS")
+
+
+def charging_mode() -> str:
+    """Return the rollout mode, preserving the legacy boolean as a fallback."""
+    if _CHARGING_MODE_ENV in _CHARGING_MODES:
+        return _CHARGING_MODE_ENV
+    if _CHARGING_MODE_ENV:
+        logger.error("Invalid GRID_CHARGING_MODE=%r; failing closed with charging off", _CHARGING_MODE_ENV)
+        return "off"
+    return "on" if CHARGING_ENABLED else "off"
+
+
+def charging_enabled_for(user: dict | None = None, model: str | None = None) -> bool:
+    """Whether this request may create a live monetary reservation.
+
+    In allowlist mode an account or service principal must be explicitly
+    selected. The optional model list narrows that cohort; it never enables
+    charging by itself.
+    """
+    mode = charging_mode()
+    if mode == "off":
+        return False
+    if mode == "on":
+        return True
+    user = user or {}
+    account_id = str(user.get("account_id") or "").lower()
+    service_id = str(user.get("service_id") or "").lower()
+    selected = (
+        bool(account_id and account_id in CHARGING_ALLOW_ACCOUNTS)
+        or bool(service_id and service_id in CHARGING_ALLOW_SERVICES)
+    )
+    if not selected:
+        return False
+    if CHARGING_ALLOW_MODELS and model is not None:
+        return str(model or "").lower() in CHARGING_ALLOW_MODELS
+    return True
+
+
+def _economic_alert(kind: str, severity: str, summary: str, *, account=None, job=None, **fields) -> None:
+    from . import alerts
+
+    if account is not None:
+        fields["account"] = alerts.opaque_id(account)
+    if job is not None:
+        fields["job"] = alerts.opaque_id(job)
+    alerts.emit(kind, severity, summary, fields=fields, dedupe_key=f"{kind}:{fields.get('account', '-')}")
 
 # ── >=100k-AIPG holder discount (dark by default) ──────────────────────────
 # A login wallet holding >= GRID_HOLDER_MIN_AIPG AIPG on Base pays a percentage
@@ -328,7 +389,7 @@ async def charge_request(user: dict, model: str, prompt_tokens: int, completion_
         return {"status": "legacy", "charged": 0}
     cost = await apply_holder_discount(cost, wallet=user.get("wallet"), account_id=aid)
     wallet = user.get("wallet")
-    if not CHARGING_ENABLED:
+    if not charging_enabled_for(user, model):
         # Preview the free-first split for observability (no consume in dry-run).
         promo_avail = await promotions.available_micro(aid)
         from_promo = min(cost, promo_avail)
@@ -356,6 +417,15 @@ async def charge_request(user: dict, model: str, prompt_tokens: int, completion_
         await free_credits.release(aid, str(job_id))
         logger.warning("account=%s insufficient credit for %d micro-USD (model=%s, free-applied=%d)",
                        aid, remainder, model, from_free)
+        _economic_alert(
+            "insufficient_credit",
+            "warning",
+            "A charge was rejected because the account had insufficient spendable credit.",
+            account=aid,
+            job=job_id,
+            model=model,
+            required_micro=remainder,
+        )
     return {"status": status,
             "charged": cost if status == "ok" else 0,
             "from_promo": from_promo,
@@ -382,9 +452,18 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
     be written. Idempotent: a retry with the same job_id re-uses the existing
     reservation (debit returns 'already' on the duplicate ref).
     """
-    if not CHARGING_ENABLED:
+    if not charging_enabled_for(user, model):
         return {"ok": True, "reserved": 0, "status": "dry_run"}
     if not pricing.is_priced_for(model, "text"):
+        _economic_alert(
+            "unpriced_work_blocked",
+            "critical",
+            "A live text request was blocked because no applicable price exists.",
+            account=_account_id(user),
+            job=job_id,
+            model=model,
+            modality="text",
+        )
         return {"ok": False, "reserved": 0, "status": "unpriced",
                 "reason": f"model '{model}' has no text price"}
     input_rate, output_rate = _snapshot_rates(model)
@@ -400,6 +479,15 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 "reason": "billing requires a v2 account key"}
     service_ok, service_reason = await service_limits.authorize(user, cost, str(job_id))
     if not service_ok:
+        _economic_alert(
+            "service_exposure_blocked",
+            "warning",
+            "A service request exceeded its configured monetary exposure limit.",
+            account=aid,
+            job=job_id,
+            service=user.get("service_id") or "-",
+            model=model,
+        )
         return {"ok": False, "reserved": 0, "status": "service_limit",
                 "reason": service_reason}
     # PROMO → DAILY FREE → PAID. Idempotent on job_id — a retry sees the same split. The free
@@ -424,6 +512,14 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                     return {"ok": True, "reserved": reserved, "status": "already"}
                 await service_limits.release(user.get("service_id"), ref)
                 logger.error("reservation debit exists without reservation row job=%s account=%s", job_id, aid)
+                _economic_alert(
+                    "reservation_inconsistent",
+                    "critical",
+                    "A debit exists without its durable reservation row.",
+                    account=aid,
+                    job=job_id,
+                    model=model,
+                )
                 return {"ok": False, "reserved": 0, "status": "reservation_missing",
                         "reason": "billing reservation is inconsistent; retry with a new request id"}
             if status == "insufficient":
@@ -433,6 +529,15 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 await service_limits.release(user.get("service_id"), ref)
                 logger.info("[charge:402] account=%s model=%s reserve=%d micro-USD (free=%d): insufficient",
                             aid, model, cost, from_free)
+                _economic_alert(
+                    "insufficient_credit",
+                    "warning",
+                    "A text request was rejected before dispatch for insufficient spendable credit.",
+                    account=aid,
+                    job=job_id,
+                    model=model,
+                    required_micro=cost,
+                )
                 return {"ok": False, "reserved": 0, "status": "insufficient",
                         "reason": "insufficient credits"}
             try:
@@ -450,6 +555,14 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 await _promo_release(aid, ref)
                 await free_credits.release(aid, ref)
                 await service_limits.release(user.get("service_id"), ref)
+                _economic_alert(
+                    "reservation_conflict",
+                    "critical",
+                    "A reservation insert conflicted without a readable durable hold.",
+                    account=aid,
+                    job=job_id,
+                    model=model,
+                )
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             except Exception:
@@ -458,6 +571,14 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 await _promo_release(aid, ref)
                 await free_credits.release(aid, ref)
                 await service_limits.release(user.get("service_id"), ref)
+                _economic_alert(
+                    "reservation_failed",
+                    "critical",
+                    "A text reservation failed before dispatch.",
+                    account=aid,
+                    job=job_id,
+                    model=model,
+                )
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             await s.commit()
@@ -487,7 +608,7 @@ async def reconcile(user: dict, model: str, prompt_tokens: int, completion_token
     the response already went out, so a settlement failure must NEVER crash it —
     a failed refund is money owed to the user, never a giveaway. Idempotent via
     job-scoped refs (`:refund` / `:extra`)."""
-    if not CHARGING_ENABLED:
+    if not charging_enabled_for(user, model):
         return
     aid = _account_id(user)
     if not aid or reserved_micro <= 0:
@@ -507,8 +628,25 @@ async def reconcile(user: dict, model: str, prompt_tokens: int, completion_token
             if extra != "ok":
                 logger.warning("reconcile under-collected account=%s job=%s by %d micro-USD (%s)",
                                aid, job_id, -diff, extra)
+                _economic_alert(
+                    "settlement_under_collected",
+                    "critical",
+                    "A completed request exceeded its reservation and the shortfall could not be collected.",
+                    account=aid,
+                    job=job_id,
+                    model=model,
+                    shortfall_micro=-diff,
+                )
     except Exception:
         logger.error("reconcile failed account=%s job=%s (refund may be owed)", aid, job_id, exc_info=True)
+        _economic_alert(
+            "reconcile_failed",
+            "critical",
+            "Post-completion reconciliation failed; a refund may be owed.",
+            account=aid,
+            job=job_id,
+            model=model,
+        )
 
 
 async def authorize_media(account_id, model: str, job_type: str, n: int, seconds, job_id,
@@ -522,9 +660,19 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
     When `record_reservation=True`, the debit and `grid_reservations` row commit
     in one transaction — the durable worker-WS lifecycle (prompt_toks=0 since media
     isn't token-priced; settle_exact ignores it)."""
-    if not CHARGING_ENABLED:
+    billing_user = user or {"account_id": account_id}
+    if not charging_enabled_for(billing_user, model):
         return {"ok": True, "reserved": 0, "status": "dry_run"}
     if not pricing.is_priced_for(model, job_type):
+        _economic_alert(
+            "unpriced_work_blocked",
+            "critical",
+            "A live media request was blocked because no applicable price exists.",
+            account=account_id,
+            job=job_id,
+            model=model,
+            modality=job_type,
+        )
         return {"ok": False, "reserved": 0, "status": "unpriced",
                 "reason": f"model '{model}' has no {job_type} price"}
     if job_type == "video":
@@ -545,6 +693,16 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
         user or {"account_id": account_id}, cost, str(job_id),
     )
     if not service_ok:
+        _economic_alert(
+            "service_exposure_blocked",
+            "warning",
+            "A service media request exceeded its configured monetary exposure limit.",
+            account=account_id,
+            job=job_id,
+            service=(user or {}).get("service_id") or "-",
+            model=model,
+            modality=job_type,
+        )
         return {"ok": False, "reserved": 0, "status": "service_limit",
                 "reason": service_reason}
     # PROMO → DAILY FREE → PAID (same contract as authorize_request).
@@ -567,6 +725,15 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                     return {"ok": True, "reserved": reserved, "status": "already"}
                 await service_limits.release((user or {}).get("service_id"), ref)
                 logger.error("media reserve debit exists without reservation row job=%s account=%s", job_id, account_id)
+                _economic_alert(
+                    "reservation_inconsistent",
+                    "critical",
+                    "A media debit exists without its durable reservation row.",
+                    account=account_id,
+                    job=job_id,
+                    model=model,
+                    modality=job_type,
+                )
                 return {"ok": False, "reserved": 0, "status": "reservation_missing",
                         "reason": "billing reservation is inconsistent; retry with a new request id"}
             if status == "insufficient":
@@ -576,6 +743,16 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                 await service_limits.release((user or {}).get("service_id"), ref)
                 logger.info("[charge:402] account=%s model=%s reserve=%d micro-USD (free=%d): insufficient",
                             account_id, model, cost, from_free)
+                _economic_alert(
+                    "insufficient_credit",
+                    "warning",
+                    "A media request was rejected before dispatch for insufficient spendable credit.",
+                    account=account_id,
+                    job=job_id,
+                    model=model,
+                    modality=job_type,
+                    required_micro=cost,
+                )
                 return {"ok": False, "reserved": 0, "status": "insufficient", "reason": "insufficient credits"}
             try:
                 await _insert_reservation_in_session(s, job_id, account_id, model, cost, 0,
@@ -589,6 +766,15 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                 await _promo_release(account_id, ref)
                 await free_credits.release(account_id, ref)
                 await service_limits.release((user or {}).get("service_id"), ref)
+                _economic_alert(
+                    "reservation_failed",
+                    "critical",
+                    "A media reservation failed before dispatch.",
+                    account=account_id,
+                    job=job_id,
+                    model=model,
+                    modality=job_type,
+                )
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             except Exception:
@@ -597,6 +783,15 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                 await _promo_release(account_id, ref)
                 await free_credits.release(account_id, ref)
                 await service_limits.release((user or {}).get("service_id"), ref)
+                _economic_alert(
+                    "reservation_failed",
+                    "critical",
+                    "A media reservation failed before dispatch.",
+                    account=account_id,
+                    job=job_id,
+                    model=model,
+                    modality=job_type,
+                )
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             await s.commit()
@@ -623,7 +818,7 @@ async def refund_reservation(account_id, reserved_micro: int, job_id) -> None:
     Free-aware: the free portion (recorded under the job ref) goes back to the
     day's allowance; only the paid remainder is credited. Best-effort +
     idempotent on the `:refund` ref and the free ref; never raises."""
-    if not CHARGING_ENABLED or not account_id or reserved_micro <= 0:
+    if not account_id or reserved_micro <= 0:
         return
     try:
         promo_held = await promotions.held_micro(account_id, str(job_id))
@@ -634,6 +829,13 @@ async def refund_reservation(account_id, reserved_micro: int, job_id) -> None:
             await credit(account_id, paid_portion, reason="refund:media", ref=f"{job_id}:refund")
     except Exception:
         logger.error("media refund failed account=%s job=%s (refund owed)", account_id, job_id, exc_info=True)
+        _economic_alert(
+            "media_refund_failed",
+            "critical",
+            "A failed media job could not be refunded automatically.",
+            account=account_id,
+            job=job_id,
+        )
 
 
 # ── Durable per-job reservation lifecycle (worker-WS is the sole settler) ─────
@@ -650,8 +852,8 @@ async def open_reservation(job_id, account_id, model: str, reserved_micro: int, 
     """Record durable billing context for a job so the worker-WS terminal handler
     can settle it without the HTTP collector. Idempotent on job_id (a requeued
     job keeps its ORIGINAL held row + reservation). Best-effort; never raises.
-    No-op in dry-run so the system still ships dark (no credit-table writes)."""
-    if not CHARGING_ENABLED:
+    No-op when no positive hold was created."""
+    if not account_id or reserved_micro <= 0:
         return
     try:
         async with await new_session() as s:
@@ -662,6 +864,14 @@ async def open_reservation(job_id, account_id, model: str, reserved_micro: int, 
                 await s.rollback()  # already opened (retry/requeue) — keep the original
     except Exception:
         logger.error("open_reservation failed job=%s (settlement context missing)", job_id, exc_info=True)
+        _economic_alert(
+            "reservation_open_failed",
+            "critical",
+            "A durable reservation context could not be opened.",
+            account=account_id,
+            job=job_id,
+            model=model,
+        )
 
 
 async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> None:
@@ -713,17 +923,6 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
             paid_held = reserved - free_held - promo_held
             service_id = row[9]
 
-            if not CHARGING_ENABLED:
-                if status == "ok":
-                    cost = pricing.quote_text(model, prompt_toks, int(completion_tokens or 0))
-                    logger.info("[settle:dry] job=%s account=%s model=%s in=%d out=%d "
-                                "would_charge=%d micro-USD ($%.4f)", job_id, aid, model,
-                                prompt_toks, completion_tokens, cost, cost / 1_000_000)
-                else:
-                    logger.info("[settle:dry] job=%s released (status=%s)", job_id, status)
-                await s.commit()
-                return
-
             if aid and reserved > 0:
                 # Two pockets, never converted: the paid refund moves in THIS txn;
                 # the free restore is a Redis op queued for after commit (a crash
@@ -761,6 +960,15 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
                         if not extra_ok:
                             logger.warning("settle under-collected account=%s job=%s by %d micro-USD (insufficient)",
                                            aid, job_id, -paid_diff)
+                            _economic_alert(
+                                "settlement_under_collected",
+                                "critical",
+                                "A completed request exceeded its reservation and the shortfall could not be collected.",
+                                account=aid,
+                                job=job_id,
+                                model=model,
+                                shortfall_micro=-paid_diff,
+                            )
             await s.commit()
         if free_restore is not None:
             await free_credits.release(free_restore[0], str(job_id), keep_micro=free_restore[1])
@@ -770,6 +978,12 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
             await service_limits.reconcile(service_reconcile[0], str(job_id), service_reconcile[1])
     except Exception:
         logger.error("settle_job failed job=%s (refund may be owed)", job_id, exc_info=True)
+        _economic_alert(
+            "settlement_failed",
+            "critical",
+            "Durable job settlement failed; the hold remains recoverable.",
+            job=job_id,
+        )
 
 
 async def settle_exact(job_id) -> None:
@@ -799,6 +1013,12 @@ async def settle_exact(job_id) -> None:
             await _promo_release(promo_finalize[0], str(job_id), keep_micro=promo_finalize[1])
     except Exception:
         logger.error("settle_exact failed job=%s", job_id, exc_info=True)
+        _economic_alert(
+            "settlement_failed",
+            "critical",
+            "Exact-cost media settlement failed; the hold remains recoverable.",
+            job=job_id,
+        )
 
 
 async def release_job(job_id) -> None:
@@ -864,6 +1084,14 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
                 # No payout, no charge — the wasted work is the tradeoff for the
                 # race. (Caller logs; this never silently double-accounts.)
                 await s.rollback()
+                _economic_alert(
+                    "late_success_no_payout",
+                    "warning",
+                    "A worker success arrived after its demand reservation was already closed.",
+                    account=row[0],
+                    job=job_id,
+                    model=row[1],
+                )
                 return "stale_no_payout"
 
             aid, model = row[0], row[1]
@@ -875,7 +1103,7 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
             free_restore = None  # (keep_micro) — Redis, applied after commit
             promo_restore = None
             service_keep = reserved
-            if CHARGING_ENABLED and aid and reserved > 0 and not exact:
+            if aid and reserved > 0 and not exact:
                 if row[6] is not None and row[7] is not None:
                     actual = _quote_snapshot(
                         prompt_toks, completion_tokens, int(row[6]), int(row[7]), int(row[8] or 0),
@@ -905,6 +1133,15 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
                     if not ok:
                         logger.warning("settle under-collected account=%s job=%s by %d micro-USD (insufficient)",
                                        aid, job_id, -paid_diff)
+                        _economic_alert(
+                            "settlement_under_collected",
+                            "critical",
+                            "An atomic terminal exceeded its hold and the shortfall could not be collected.",
+                            account=aid,
+                            job=job_id,
+                            model=model,
+                            shortfall_micro=-paid_diff,
+                        )
             await s.commit()
             if exact and promo_held > 0:
                 promo_restore = promo_held
@@ -916,6 +1153,12 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
             return "settled"
     except Exception:
         logger.error("record_and_settle failed job=%s (terminal not committed; retryable)", job_id, exc_info=True)
+        _economic_alert(
+            "atomic_terminal_failed",
+            "critical",
+            "Worker payout and demand settlement did not commit; the terminal is retryable.",
+            job=job_id,
+        )
         return "error"
 
 
@@ -941,10 +1184,9 @@ async def sweep_stale_reservations(older_than_seconds: int = 3600, limit: int = 
         settlement didn't commit (crash between ledger + settle) → SETTLE it
         (charge), never refund.
       * otherwise the job never produced output → RELEASE (full refund).
-    Returns the total number of reservations acted on. No-op in dry-run.
+    Returns the total number of reservations acted on. Existing holds are swept
+    even after charging is disabled; the rollout mode controls new holds only.
     Idempotent: settle/release re-flip already-settled rows to a no-op."""
-    if not CHARGING_ENABLED:
-        return 0
     cutoff = _now() - _dt.timedelta(seconds=older_than_seconds)
     async with await new_session() as s:
         rows = (await s.execute(
@@ -970,4 +1212,72 @@ async def sweep_stale_reservations(older_than_seconds: int = 3600, limit: int = 
     if job_ids:
         logger.warning("swept stale held reservations older than %ds: %d released, %d settled-from-ledger",
                        older_than_seconds, released, settled)
+        _economic_alert(
+            "stale_reservations_recovered",
+            "warning",
+            "The reservation sweeper recovered stale monetary holds.",
+            released=released,
+            settled=settled,
+            age_seconds=older_than_seconds,
+        )
     return released + settled
+
+
+async def billing_health(held_warning_seconds: int = 900) -> dict[str, int | bool]:
+    """Read-only economic invariants for the operator monitor.
+
+    The purchased-balance cache must equal the append-only purchased ledger in
+    aggregate. Promotional and daily-free pockets intentionally live elsewhere
+    and are excluded from both sides of this invariant.
+    """
+    held_cutoff = _now() - _dt.timedelta(seconds=max(0, held_warning_seconds))
+    async with await new_session() as s:
+        balance_total = int(
+            await s.scalar(sa.select(sa.func.coalesce(sa.func.sum(credits_t.c.balance_micro), 0)))
+            or 0
+        )
+        ledger_total = int(
+            await s.scalar(sa.select(sa.func.coalesce(sa.func.sum(ledger_t.c.delta_micro), 0)))
+            or 0
+        )
+        negative_balances = int(
+            await s.scalar(
+                sa.select(sa.func.count()).select_from(credits_t).where(credits_t.c.balance_micro < 0),
+            )
+            or 0
+        )
+        stale_held = int(
+            await s.scalar(
+                sa.select(sa.func.count())
+                .select_from(reservations_t)
+                .where(
+                    reservations_t.c.status == "held",
+                    reservations_t.c.created < held_cutoff,
+                ),
+            )
+            or 0
+        )
+        invalid_splits = int(
+            await s.scalar(
+                sa.select(sa.func.count())
+                .select_from(reservations_t)
+                .where(
+                    reservations_t.c.free_micro + reservations_t.c.promo_micro
+                    > reservations_t.c.reserved_micro,
+                ),
+            )
+            or 0
+        )
+    return {
+        "ok": (
+            balance_total == ledger_total
+            and negative_balances == 0
+            and invalid_splits == 0
+        ),
+        "balance_total_micro": balance_total,
+        "ledger_total_micro": ledger_total,
+        "balance_delta_micro": balance_total - ledger_total,
+        "negative_balances": negative_balances,
+        "stale_held": stale_held,
+        "invalid_reservation_splits": invalid_splits,
+    }

--- a/grid_api/services/credits.py
+++ b/grid_api/services/credits.py
@@ -81,7 +81,8 @@ async def apply_holder_discount(cost_micro: int, *, wallet: str | None = None, a
     discount = await holder_discount_bps(wallet=wallet, account_id=account_id)
     if cost_micro <= 0 or discount <= 0:
         return cost_micro
-    return int(cost_micro * (10_000 - discount) // 10_000)
+    factor = 10_000 - discount
+    return (cost_micro * factor + 9_999) // 10_000 if factor > 0 else 0
 
 
 async def holder_discount_bps(*, wallet: str | None = None, account_id=None) -> int:
@@ -115,11 +116,10 @@ def _snapshot_rates(model: str) -> tuple[int, int]:
 
 def _quote_snapshot(prompt_tokens: int, completion_tokens: int, input_rate: int,
                     output_rate: int, discount_bps: int) -> int:
-    base = int(round(
-        (int(prompt_tokens or 0) * input_rate + int(completion_tokens or 0) * output_rate)
-        / pricing.MICRO
-    ))
-    return base * (10_000 - max(0, min(int(discount_bps or 0), 10_000))) // 10_000
+    numerator = int(prompt_tokens or 0) * input_rate + int(completion_tokens or 0) * output_rate
+    base = (numerator + pricing.MICRO - 1) // pricing.MICRO if numerator > 0 else 0
+    factor = 10_000 - max(0, min(int(discount_bps or 0), 10_000))
+    return (base * factor + 9_999) // 10_000 if base > 0 and factor > 0 else 0
 
 
 async def get_balance(account_id) -> int:
@@ -384,9 +384,9 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
     """
     if not CHARGING_ENABLED:
         return {"ok": True, "reserved": 0, "status": "dry_run"}
-    if not pricing.is_priced(model):
+    if not pricing.is_priced_for(model, "text"):
         return {"ok": False, "reserved": 0, "status": "unpriced",
-                "reason": f"model '{model}' is not available for billing"}
+                "reason": f"model '{model}' has no text price"}
     input_rate, output_rate = _snapshot_rates(model)
     discount_bps = await holder_discount_bps(
         wallet=user.get("wallet"), account_id=_account_id(user),
@@ -422,6 +422,7 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 reserved = await _reservation_reserved_micro(job_id)
                 if reserved is not None:
                     return {"ok": True, "reserved": reserved, "status": "already"}
+                await service_limits.release(user.get("service_id"), ref)
                 logger.error("reservation debit exists without reservation row job=%s account=%s", job_id, aid)
                 return {"ok": False, "reserved": 0, "status": "reservation_missing",
                         "reason": "billing reservation is inconsistent; retry with a new request id"}
@@ -429,6 +430,7 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 await s.rollback()
                 await _promo_release(aid, ref)
                 await free_credits.release(aid, ref)  # give back the free we just took
+                await service_limits.release(user.get("service_id"), ref)
                 logger.info("[charge:402] account=%s model=%s reserve=%d micro-USD (free=%d): insufficient",
                             aid, model, cost, from_free)
                 return {"ok": False, "reserved": 0, "status": "insufficient",
@@ -447,6 +449,7 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 logger.error("reservation insert conflicted without readable row job=%s account=%s", job_id, aid)
                 await _promo_release(aid, ref)
                 await free_credits.release(aid, ref)
+                await service_limits.release(user.get("service_id"), ref)
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             except Exception:
@@ -454,6 +457,7 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 logger.error("reservation insert failed job=%s account=%s", job_id, aid, exc_info=True)
                 await _promo_release(aid, ref)
                 await free_credits.release(aid, ref)
+                await service_limits.release(user.get("service_id"), ref)
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             await s.commit()
@@ -469,6 +473,7 @@ async def authorize_request(user: dict, model: str, prompt_tokens: int, max_toke
                 "from_promo": from_promo, "from_free": from_free}
     await _promo_release(aid, ref)
     await free_credits.release(aid, ref)
+    await service_limits.release(user.get("service_id"), ref)
     logger.info("[charge:402] account=%s model=%s reserve=%d micro-USD (free=%d): insufficient",
                 aid, model, cost, from_free)
     return {"ok": False, "reserved": 0, "status": "insufficient",
@@ -519,9 +524,9 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
     isn't token-priced; settle_exact ignores it)."""
     if not CHARGING_ENABLED:
         return {"ok": True, "reserved": 0, "status": "dry_run"}
-    if not pricing.is_priced(model):
+    if not pricing.is_priced_for(model, job_type):
         return {"ok": False, "reserved": 0, "status": "unpriced",
-                "reason": f"model '{model}' is not available for billing"}
+                "reason": f"model '{model}' has no {job_type} price"}
     if job_type == "video":
         cost = pricing.quote_video(model, float(seconds or 0))
     elif job_type == "audio":
@@ -560,6 +565,7 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                 reserved = await _reservation_reserved_micro(job_id)
                 if reserved is not None:
                     return {"ok": True, "reserved": reserved, "status": "already"}
+                await service_limits.release((user or {}).get("service_id"), ref)
                 logger.error("media reserve debit exists without reservation row job=%s account=%s", job_id, account_id)
                 return {"ok": False, "reserved": 0, "status": "reservation_missing",
                         "reason": "billing reservation is inconsistent; retry with a new request id"}
@@ -567,6 +573,7 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                 await s.rollback()
                 await _promo_release(account_id, ref)
                 await free_credits.release(account_id, ref)
+                await service_limits.release((user or {}).get("service_id"), ref)
                 logger.info("[charge:402] account=%s model=%s reserve=%d micro-USD (free=%d): insufficient",
                             account_id, model, cost, from_free)
                 return {"ok": False, "reserved": 0, "status": "insufficient", "reason": "insufficient credits"}
@@ -581,6 +588,7 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                     return {"ok": True, "reserved": reserved, "status": "already"}
                 await _promo_release(account_id, ref)
                 await free_credits.release(account_id, ref)
+                await service_limits.release((user or {}).get("service_id"), ref)
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             except Exception:
@@ -588,6 +596,7 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                 logger.error("media reservation insert failed job=%s account=%s", job_id, account_id, exc_info=True)
                 await _promo_release(account_id, ref)
                 await free_credits.release(account_id, ref)
+                await service_limits.release((user or {}).get("service_id"), ref)
                 return {"ok": False, "reserved": 0, "status": "reservation_failed",
                         "reason": "billing reservation failed"}
             await s.commit()
@@ -603,6 +612,7 @@ async def authorize_media(account_id, model: str, job_type: str, n: int, seconds
                 "from_promo": from_promo, "from_free": from_free}
     await _promo_release(account_id, ref)
     await free_credits.release(account_id, ref)
+    await service_limits.release((user or {}).get("service_id"), ref)
     logger.info("[charge:402] account=%s model=%s reserve=%d micro-USD (free=%d): insufficient",
                 account_id, model, cost, from_free)
     return {"ok": False, "reserved": 0, "status": "insufficient", "reason": "insufficient credits"}
@@ -668,6 +678,7 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
     and retryable instead of marking it settled prematurely."""
     free_restore = None  # (account_id, keep_micro) — applied AFTER the SQL commit
     promo_restore = None  # (account_id, keep_micro) — durable promo pocket
+    service_reconcile = None  # (service_id, actual_micro) — Redis after commit
     try:
         async with await new_session() as s:
             row = (await s.execute(
@@ -676,7 +687,8 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
                           reservations_t.c.free_micro, reservations_t.c.promo_micro,
                           reservations_t.c.input_per_mtok_micro,
                           reservations_t.c.output_per_mtok_micro,
-                          reservations_t.c.discount_bps)
+                          reservations_t.c.discount_bps,
+                          reservations_t.c.service_id)
                 .where(reservations_t.c.job_id == str(job_id))
             )).first()
             if not row:
@@ -699,6 +711,7 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
             free_held = int(row[4] or 0)
             promo_held = int(row[5] or 0)
             paid_held = reserved - free_held - promo_held
+            service_id = row[9]
 
             if not CHARGING_ENABLED:
                 if status == "ok":
@@ -716,6 +729,7 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
                 # the free restore is a Redis op queued for after commit (a crash
                 # between them forfeits free-day allowance, never paid money).
                 if status != "ok":
+                    service_reconcile = (service_id, 0)
                     if paid_held > 0:
                         await _credit_in_session(s, paid_account_id, paid_held, "release:failed", f"{job_id}:refund", model)
                     if free_held > 0:
@@ -729,6 +743,7 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
                         )
                     else:
                         actual = pricing.quote_text(model, prompt_toks, int(completion_tokens or 0))
+                    service_reconcile = (service_id, actual)
                     # Attribute consumption promo → daily free → paid, matching reserve.
                     promo_spent = min(promo_held, actual)
                     after_promo = actual - promo_spent
@@ -751,6 +766,8 @@ async def settle_job(job_id, completion_tokens: int, *, status: str = "ok") -> N
             await free_credits.release(free_restore[0], str(job_id), keep_micro=free_restore[1])
         if promo_restore is not None:
             await _promo_release(promo_restore[0], str(job_id), keep_micro=promo_restore[1])
+        if service_reconcile is not None:
+            await service_limits.reconcile(service_reconcile[0], str(job_id), service_reconcile[1])
     except Exception:
         logger.error("settle_job failed job=%s (refund may be owed)", job_id, exc_info=True)
 
@@ -825,7 +842,8 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
                           reservations_t.c.free_micro, reservations_t.c.promo_micro,
                           reservations_t.c.input_per_mtok_micro,
                           reservations_t.c.output_per_mtok_micro,
-                          reservations_t.c.discount_bps)
+                          reservations_t.c.discount_bps,
+                          reservations_t.c.service_id)
                 .where(reservations_t.c.job_id == job_id)
             )).first()
             if not row:
@@ -856,6 +874,7 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
             promo_held = int(row[5] or 0)
             free_restore = None  # (keep_micro) — Redis, applied after commit
             promo_restore = None
+            service_keep = reserved
             if CHARGING_ENABLED and aid and reserved > 0 and not exact:
                 if row[6] is not None and row[7] is not None:
                     actual = _quote_snapshot(
@@ -864,6 +883,7 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
                 else:
                     # Compatibility for reservations opened before migration 0015.
                     actual = pricing.quote_text(model, prompt_toks, int(completion_tokens or 0))
+                service_keep = actual
                 # Three pockets, never converted: promo → daily free → paid
                 # (matching the draw); the paid refund/extra moves in THIS txn,
                 # the free restore follows the commit (crash between = free-day
@@ -892,6 +912,7 @@ async def record_and_settle(*, ledger_values: dict, completion_tokens: int = 0,
                 await free_credits.release(aid, job_id, keep_micro=free_restore)
             if promo_restore is not None:
                 await _promo_release(aid, job_id, keep_micro=promo_restore)
+            await service_limits.reconcile(row[9], job_id, service_keep)
             return "settled"
     except Exception:
         logger.error("record_and_settle failed job=%s (terminal not committed; retryable)", job_id, exc_info=True)

--- a/grid_api/services/deposits.py
+++ b/grid_api/services/deposits.py
@@ -26,7 +26,7 @@ import os
 import httpx
 from fastapi import HTTPException
 
-from . import credits
+from . import alerts, credits
 
 logger = logging.getLogger("grid_api.deposits")
 
@@ -77,6 +77,13 @@ async def verify_and_credit(tx_hash: str, account: dict) -> dict:
         receipt = await _rpc("eth_getTransactionReceipt", [tx_hash])
     except Exception as e:
         logger.warning("deposit rpc failed for %s: %s", tx_hash, e)
+        alerts.emit(
+            "deposit_rpc_failed",
+            "critical",
+            "A USDC deposit claim could not be verified against Base.",
+            fields={"asset": "USDC", "tx": alerts.opaque_id(tx_hash), "error_type": type(e).__name__},
+            dedupe_key="deposit-rpc:usdc",
+        )
         raise HTTPException(502, detail="Could not reach Base to verify the transaction.")
     if not receipt:
         raise HTTPException(400, detail="Transaction not found or not yet mined.")
@@ -115,12 +122,36 @@ async def verify_and_credit(tx_hash: str, account: dict) -> dict:
     if not acct_wallet:
         raise HTTPException(403, detail="Link a wallet (sign in with your wallet) before claiming deposits.")
     if acct_wallet != sender:
+        alerts.emit(
+            "deposit_wallet_mismatch",
+            "warning",
+            "A deposit claim was rejected because its sender did not match the authenticated wallet.",
+            fields={
+                "asset": "USDC",
+                "account": alerts.opaque_id(account.get("account_id")),
+                "tx": alerts.opaque_id(tx_hash),
+            },
+            dedupe_key=f"deposit-wallet-mismatch:{alerts.opaque_id(account.get('account_id'))}",
+        )
         raise HTTPException(403, detail="This deposit was sent from a different wallet than your account's.")
 
     applied = await credits.credit(
         account["account_id"], value_micro, reason="usdc_deposit", ref=f"usdc:{tx_hash}"
     )
     balance = await credits.get_balance(account["account_id"])
+    if applied:
+        alerts.emit(
+            "deposit_credited",
+            "success",
+            "A verified Base deposit was credited to a Grid account.",
+            fields={
+                "asset": "USDC",
+                "account": alerts.opaque_id(account["account_id"]),
+                "tx": alerts.opaque_id(tx_hash),
+                "amount_micro": value_micro,
+            },
+            dedupe_key=f"deposit-credited:usdc:{alerts.opaque_id(tx_hash)}",
+        )
     return {
         "credited": bool(applied),
         "already_claimed": not applied,
@@ -152,6 +183,13 @@ async def verify_and_credit_eth(tx_hash: str, account: dict) -> dict:
         receipt = await _rpc("eth_getTransactionReceipt", [tx_hash])
     except Exception as e:
         logger.warning("eth deposit rpc failed for %s: %s", tx_hash, e)
+        alerts.emit(
+            "deposit_rpc_failed",
+            "critical",
+            "An ETH deposit claim could not be verified against Base.",
+            fields={"asset": "ETH", "tx": alerts.opaque_id(tx_hash), "error_type": type(e).__name__},
+            dedupe_key="deposit-rpc:eth",
+        )
         raise HTTPException(502, detail="Could not reach Base to verify the transaction.")
     if not tx or not receipt:
         raise HTTPException(400, detail="Transaction not found or not yet mined.")
@@ -181,6 +219,17 @@ async def verify_and_credit_eth(tx_hash: str, account: dict) -> dict:
     if not acct_wallet:
         raise HTTPException(403, detail="Link a wallet (sign in with your wallet) before claiming deposits.")
     if acct_wallet != sender:
+        alerts.emit(
+            "deposit_wallet_mismatch",
+            "warning",
+            "A deposit claim was rejected because its sender did not match the authenticated wallet.",
+            fields={
+                "asset": "ETH",
+                "account": alerts.opaque_id(account.get("account_id")),
+                "tx": alerts.opaque_id(tx_hash),
+            },
+            dedupe_key=f"deposit-wallet-mismatch:{alerts.opaque_id(account.get('account_id'))}",
+        )
         raise HTTPException(403, detail="This deposit was sent from a different wallet than your account's.")
 
     # Price ETH→USD at claim time (Chainlink on Base). Never guess a price.
@@ -189,6 +238,13 @@ async def verify_and_credit_eth(tx_hash: str, account: dict) -> dict:
         px_micro = await holdings.eth_usd_micro()  # micro-USD per 1 ETH
     except Exception as e:
         logger.warning("eth/usd price read failed for deposit %s: %s", tx_hash, e)
+        alerts.emit(
+            "deposit_oracle_failed",
+            "critical",
+            "An ETH deposit could not be priced from the Base Chainlink feed.",
+            fields={"asset": "ETH", "tx": alerts.opaque_id(tx_hash), "error_type": type(e).__name__},
+            dedupe_key="deposit-oracle:eth-usd",
+        )
         raise HTTPException(502, detail="Could not read the ETH/USD price feed; retry shortly.")
     value_micro = value_wei * px_micro // (10 ** 18)
     if value_micro <= 0:
@@ -198,6 +254,19 @@ async def verify_and_credit_eth(tx_hash: str, account: dict) -> dict:
         account["account_id"], value_micro, reason="eth_deposit", ref=f"eth:{tx_hash}"
     )
     balance = await credits.get_balance(account["account_id"])
+    if applied:
+        alerts.emit(
+            "deposit_credited",
+            "success",
+            "A verified Base deposit was credited to a Grid account.",
+            fields={
+                "asset": "ETH",
+                "account": alerts.opaque_id(account["account_id"]),
+                "tx": alerts.opaque_id(tx_hash),
+                "amount_micro": value_micro,
+            },
+            dedupe_key=f"deposit-credited:eth:{alerts.opaque_id(tx_hash)}",
+        )
     return {
         "credited": bool(applied),
         "already_claimed": not applied,

--- a/grid_api/services/free_credits.py
+++ b/grid_api/services/free_credits.py
@@ -26,7 +26,8 @@ and hold only the remainder from paid; the reservation row records the split
 and refunds paid-to-paid — the pockets never convert. The whole draw is gated on
 **GRID_FREE_SPENDABLE_LIVE** (default OFF): flag off → free is display-only and
 `/v1/account/credits` reports free.active=false / total_spendable=paid, exactly
-matching behavior. Flip it together with GRID_CHARGING_ENABLED at go-live.
+matching behavior. Enable it only alongside a reviewed
+`GRID_CHARGING_MODE=allowlist` canary or the later global rollout.
 """
 
 import logging

--- a/grid_api/services/media.py
+++ b/grid_api/services/media.py
@@ -327,26 +327,22 @@ async def submit_and_wait(model: str, job_type: str, payload: dict, timeout: int
     # transaction (record_reservation), so the worker-WS handler is the sole
     # settler (settle_exact on success / release_job on failure) and a crash can't
     # strand the hold — the sweeper releases stale 'held' rows. No-op in dry-run.
-    reserved = 0
-    if credits.CHARGING_ENABLED:
-        n = int(payload.get("n", 1) or 1)
-        seconds = payload.get("seconds") or (payload.get("recipe_inputs") or {}).get("seconds")
-        if job_type == "video" and not seconds:
-            # Bill the exact graph default. Recipe display names can share a
-            # checkpoint while baking different durations (e.g. 5s Director vs
-            # 10s Audio), so a single global fallback would undercharge one.
-            seconds = recipes.baked_default_for_model(
-                model,
-                "seconds",
-                payload.get("recipe_inputs") or {},
-                has_source=bool(payload.get("source_image_url")),
-            ) or DEFAULT_VIDEO_SECONDS
-        auth = await credits.authorize_media(account_id, model, job_type, n, seconds, job_id,
-                                             record_reservation=True, user=billing_user)
-        if not auth["ok"]:
-            raise HTTPException(status_code=402, detail=auth.get("reason", "payment required"))
-        reserved = auth["reserved"]
-
+    n = int(payload.get("n", 1) or 1)
+    seconds = payload.get("seconds") or (payload.get("recipe_inputs") or {}).get("seconds")
+    if job_type == "video" and not seconds:
+        # Bill the exact graph default. Recipe display names can share a
+        # checkpoint while baking different durations (e.g. 5s Director vs
+        # 10s Audio), so a single global fallback would undercharge one.
+        seconds = recipes.baked_default_for_model(
+            model,
+            "seconds",
+            payload.get("recipe_inputs") or {},
+            has_source=bool(payload.get("source_image_url")),
+        ) or DEFAULT_VIDEO_SECONDS
+    auth = await credits.authorize_media(account_id, model, job_type, n, seconds, job_id,
+                                         record_reservation=True, user=billing_user)
+    if not auth["ok"]:
+        raise HTTPException(status_code=402, detail=auth.get("reason", "payment required"))
     if account_id is not None and concurrency_limit:
         if not await _inflight_acquire(account_id, concurrency_limit):
             # Rejected BEFORE dispatch — worker_ws never sees it, so release here.

--- a/grid_api/services/media.py
+++ b/grid_api/services/media.py
@@ -332,9 +332,15 @@ async def submit_and_wait(model: str, job_type: str, payload: dict, timeout: int
         n = int(payload.get("n", 1) or 1)
         seconds = payload.get("seconds") or (payload.get("recipe_inputs") or {}).get("seconds")
         if job_type == "video" and not seconds:
-            # the recipe's baked default duration isn't known to the grid; bill a
-            # conservative default rather than letting it slip through free.
-            seconds = DEFAULT_VIDEO_SECONDS
+            # Bill the exact graph default. Recipe display names can share a
+            # checkpoint while baking different durations (e.g. 5s Director vs
+            # 10s Audio), so a single global fallback would undercharge one.
+            seconds = recipes.baked_default_for_model(
+                model,
+                "seconds",
+                payload.get("recipe_inputs") or {},
+                has_source=bool(payload.get("source_image_url")),
+            ) or DEFAULT_VIDEO_SECONDS
         auth = await credits.authorize_media(account_id, model, job_type, n, seconds, job_id,
                                              record_reservation=True, user=billing_user)
         if not auth["ok"]:

--- a/grid_api/services/pricing.py
+++ b/grid_api/services/pricing.py
@@ -1,6 +1,6 @@
-# ⚠️ WIRED-DARK (2026-06-23): the request path quotes against this book via
-# credits.charge_request, but only in dry-run (GRID_CHARGING_ENABLED=0) — the quote
-# is logged, never billed. Re-peg prices here before charging goes live. See task #73.
+# WIRED-DARK: the request path always quotes against this book, but
+# GRID_CHARGING_MODE=off only logs the quote. Re-peg and review prices before
+# expanding beyond an allowlisted canary.
 
 # SPDX-FileCopyrightText: 2026 AI Power Grid
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/grid_api/services/pricing.py
+++ b/grid_api/services/pricing.py
@@ -23,6 +23,7 @@ editing the USD numbers here; nothing converts at request time.
     cost_usd = (prompt_tokens * input_per_mtok + completion_tokens * output_per_mtok) / 1_000_000
 """
 
+import math
 from dataclasses import dataclass
 
 MICRO = 1_000_000  # micro-USD per USD (the ledger's integer unit)
@@ -57,6 +58,10 @@ def half_of(usd_input: float, usd_output: float, **media) -> ModelPrice:
 PRICING: dict[str, ModelPrice] = {
     "gpt-oss-120b":       half_of(0.15, 0.60),   # floor Fireworks/Groq
     "deepseek-v4-flash":  half_of(0.14, 0.28),   # floor Fireworks
+    # Guarded launch pegs for Grid-hosted models without a stable public API
+    # comparator. Re-peg from measured worker cost before the global live flip.
+    "qwen3-27b":          ModelPrice(0.05, 0.15),
+    "smollm-135m":        ModelPrice(0.005, 0.01),
     "deepseek-v4-pro":    half_of(0.40, 1.20),
     "minimax-2.5-fast":   half_of(0.60, 2.40),
     "minimax-2.7-fast":   half_of(0.60, 2.40),
@@ -79,14 +84,19 @@ PRICING: dict[str, ModelPrice] = {
     # enabling audio charging. Explicit pricing prevents accidental free jobs.
     # Guarded XL launch peg. The 4B DiT has roughly twice the 2B Turbo weight
     # footprint; benchmark worker cost before enabling charging and re-peg then.
-    "ace-step-v1.5-xl-turbo": ModelPrice(0, 0, audio_per_second=0.004),
+    "ace-step-v1.5-xl-turbo": ModelPrice(0, 0, audio_per_second=0.0002),
     # Initial guarded peg for a multi-minute textured mesh workload. Re-peg from
     # measured worker cost before enabling charging; explicit is safer than free.
     "trellis2":             ModelPrice(0, 0, mesh_per_generation=0.25),
 }
 
-BLOCK_UNPRICED = False  # unpriced model → 0 (free) unless flipped
-
+# Public recipe names and worker variants share the canonical model's price.
+# Aliases are explicit so an arbitrary renamed worker model still fails closed.
+PRICE_ALIASES: dict[str, str] = {
+    "deepseek-v4-flash-nvfp4": "deepseek-v4-flash",
+    "ltx director 2.0": "ltx-2.3",
+    "ltx-2.3 audio": "ltx-2.3",
+}
 
 def register(model: str, price: ModelPrice) -> None:
     if model:
@@ -94,13 +104,42 @@ def register(model: str, price: ModelPrice) -> None:
 
 
 def get_price(model: str) -> ModelPrice | None:
-    return PRICING.get((model or "").lower().strip())
+    key = (model or "").lower().strip()
+    return PRICING.get(PRICE_ALIASES.get(key, key))
 
 
 def is_priced(model: str) -> bool:
-    """True if the model has an entry in the price book. Enforce mode
-    default-denies anything unpriced so a renamed/new model can't be free."""
+    """Compatibility check for callers that do not yet know the modality."""
     return get_price(model) is not None
+
+
+def is_priced_for(model: str, job_type: str) -> bool:
+    """Return whether ``model`` has a positive rate for ``job_type``.
+
+    An entry for a different modality is not a price. This is the fail-closed
+    boundary that prevents, for example, an LTX video rate from making an image
+    request look intentionally free.
+    """
+    p = get_price(model)
+    if not p:
+        return False
+    rates = {
+        "text": p.input_per_mtok > 0 or p.output_per_mtok > 0,
+        "image": p.image_per_image > 0,
+        "video": p.video_per_second > 0,
+        "audio": p.audio_per_second > 0,
+        "3d": p.mesh_per_generation > 0,
+    }
+    return bool(rates.get((job_type or "").lower()))
+
+
+def _micro_usd(usd: float) -> int:
+    """Round a positive quote up to the smallest ledger unit.
+
+    Normal rounding made tiny but explicitly priced requests free. Ceiling keeps
+    the price book's default-deny promise while adding at most one micro-dollar.
+    """
+    return math.ceil(usd * MICRO) if usd > 0 else 0
 
 
 def quote_text(model: str, prompt_tokens: int, completion_tokens: int) -> int:
@@ -109,24 +148,24 @@ def quote_text(model: str, prompt_tokens: int, completion_tokens: int) -> int:
     if not p:
         return 0
     usd = (prompt_tokens * p.input_per_mtok + completion_tokens * p.output_per_mtok) / 1_000_000.0
-    return int(round(usd * MICRO))
+    return _micro_usd(usd)
 
 
 def quote_image(model: str, n: int = 1) -> int:
     p = get_price(model)
-    return int(round((p.image_per_image * max(n, 1)) * MICRO)) if p else 0
+    return _micro_usd(p.image_per_image * max(n, 1)) if p else 0
 
 
 def quote_video(model: str, seconds: float = 0.0) -> int:
     p = get_price(model)
-    return int(round((p.video_per_second * max(seconds, 0.0)) * MICRO)) if p else 0
+    return _micro_usd(p.video_per_second * max(seconds, 0.0)) if p else 0
 
 
 def quote_audio(model: str, seconds: float = 0.0) -> int:
     p = get_price(model)
-    return int(round((p.audio_per_second * max(seconds, 0.0)) * MICRO)) if p else 0
+    return _micro_usd(p.audio_per_second * max(seconds, 0.0)) if p else 0
 
 
 def quote_3d(model: str, n: int = 1) -> int:
     p = get_price(model)
-    return int(round((p.mesh_per_generation * max(n, 1)) * MICRO)) if p else 0
+    return _micro_usd(p.mesh_per_generation * max(n, 1)) if p else 0

--- a/grid_api/services/quota.py
+++ b/grid_api/services/quota.py
@@ -6,8 +6,9 @@
 The mission is "free AI for everyone, funded by paid usage." This is the code
 that makes the free part real: every user gets a daily allowance of requests,
 metered per UTC day in Redis. Accounts carrying an explicit ``quota_exempt``
-policy flag are unmetered. Direct first-party service keys are also unmetered
-only when they carry both fail-closed per-request and daily spending ceilings.
+policy flag or a positive purchased-credit balance are unmetered. Direct
+first-party service keys are also unmetered only when they carry both
+fail-closed per-request and daily spending ceilings.
 
 Design notes:
   - Meter ACCEPTED requests only: callers invoke this right before a request
@@ -67,6 +68,27 @@ def is_paid(user: dict) -> bool:
     )
 
 
+async def has_paid_access(user: dict) -> bool:
+    """Return whether request-count quota should not gate this credential.
+
+    Promotional and daily-free value do not qualify: only an explicit policy,
+    a bounded direct service key, or positive purchased balance does. A balance
+    lookup failure falls back to the free counter; the later billing reserve is
+    still the authoritative spend gate.
+    """
+    if is_paid(user):
+        return True
+    if not user.get("account_id"):
+        return False
+    try:
+        from . import credits
+
+        return await credits.has_credit(user)
+    except Exception as exc:
+        logger.warning("paid quota lookup failed for account %s: %s", user.get("account_id"), exc)
+        return False
+
+
 async def check_and_consume(user: dict) -> None:
     """Consume one unit of the user's daily quota; raise 429 if exhausted.
 
@@ -74,7 +96,7 @@ async def check_and_consume(user: dict) -> None:
     pass through untouched. On any Redis error we fail open (allow the request)
     so a quota-store outage doesn't break inference.
     """
-    if is_paid(user):
+    if await has_paid_access(user):
         return
 
     user_id = user.get("id")
@@ -110,7 +132,7 @@ async def check_and_consume(user: dict) -> None:
 
 async def remaining(user: dict) -> int | None:
     """Requests left today, or None for paid/unmetered users. Best-effort."""
-    if is_paid(user):
+    if await has_paid_access(user):
         return None
     user_id = user.get("id")
     if user_id is None:

--- a/grid_api/services/recipes.py
+++ b/grid_api/services/recipes.py
@@ -284,6 +284,16 @@ def _set_path(spec: dict, path: str, value: Any) -> None:
     cur[parts[-1]] = value
 
 
+def _get_path(spec: dict, path: str) -> Any:
+    """Read a declared recipe slot without mutating the graph."""
+    cur: Any = spec
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            raise RecipeError(f"slot '{path}' targets a missing path")
+        cur = cur[part]
+    return cur
+
+
 def _fmt(n: float) -> str:
     return str(int(n)) if float(n).is_integer() else str(n)
 
@@ -390,16 +400,8 @@ def resolve(ref: str | int, inputs: dict | None = None) -> dict:
     }
 
 
-def resolve_for_model(model: str, inputs: dict | None = None, *, has_source: bool = False) -> Optional[dict]:
-    """Media-layer entry point: pick the right recipe for `model` and resolve it to a
-    concrete graph spec; else return None so the caller falls back to legacy dispatch.
-
-    Variant selection: a model may have a text-only (t2i) recipe AND an image-input
-    (i2i / edit) recipe. When the job carries a source frame (`has_source`), prefer
-    the recipe that declares an `image` var; otherwise prefer the one that doesn't.
-    Falls back to whatever recipe exists if there's no exact match (e.g. LTX i2v,
-    whose only recipe takes an image but runs a baked default frame when none given).
-    `inputs` may be the raw payload — only declared vars present get injected."""
+def _recipe_for_model(model: str, inputs: dict | None = None, *,
+                      has_source: bool = False) -> Optional[Recipe]:
     cands = recipes_for_model(model)
     if not cands:
         return None
@@ -419,9 +421,41 @@ def resolve_for_model(model: str, inputs: dict | None = None, *, has_source: boo
             return False
         return True
 
-    chosen = (next((r for r in cands if _matches(r)), None)
-              or next((r for r in cands if ("image" in r.vars) == has_source), None)
-              or cands[0])
+    return (next((r for r in cands if _matches(r)), None)
+            or next((r for r in cands if ("image" in r.vars) == has_source), None)
+            or cands[0])
+
+
+def baked_default_for_model(model: str, input_name: str, inputs: dict | None = None, *,
+                            has_source: bool = False) -> Any:
+    """Return a recipe's baked value for a declared client input.
+
+    Billing uses this when a client omits a deterministic unit such as video
+    seconds. It must charge the graph that will actually run, not a global guess.
+    """
+    chosen = _recipe_for_model(model, inputs, has_source=has_source)
+    if not chosen:
+        return None
+    path = chosen.vars.get(input_name)
+    if not path:
+        return None
+    first_path = path[0] if isinstance(path, list) else path
+    return _get_path(chosen.spec, first_path)
+
+
+def resolve_for_model(model: str, inputs: dict | None = None, *, has_source: bool = False) -> Optional[dict]:
+    """Media-layer entry point: pick the right recipe for `model` and resolve it to a
+    concrete graph spec; else return None so the caller falls back to legacy dispatch.
+
+    Variant selection: a model may have a text-only (t2i) recipe AND an image-input
+    (i2i / edit) recipe. When the job carries a source frame (`has_source`), prefer
+    the recipe that declares an `image` var; otherwise prefer the one that doesn't.
+    Falls back to whatever recipe exists if there's no exact match (e.g. LTX i2v,
+    whose only recipe takes an image but runs a baked default frame when none given).
+    `inputs` may be the raw payload — only declared vars present get injected."""
+    chosen = _recipe_for_model(model, inputs, has_source=has_source)
+    if not chosen:
+        return None
     return resolve(chosen.recipe_root, inputs)
 
 

--- a/grid_api/services/service_limits.py
+++ b/grid_api/services/service_limits.py
@@ -18,7 +18,28 @@ local cap = tonumber(ARGV[2])
 if cap > 0 and used + amount > cap then return 0 end
 redis.call('INCRBY', KEYS[1], amount)
 redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
-redis.call('SET', KEYS[2], amount, 'EX', tonumber(ARGV[3]))
+redis.call('SET', KEYS[2], ARGV[4] .. ':' .. ARGV[1], 'EX', tonumber(ARGV[3]))
+return 1
+"""
+
+_RELEASE_LUA = """
+local prior = redis.call('GET', KEYS[2])
+if not prior or prior ~= ARGV[1] then return 0 end
+local amount = tonumber(ARGV[2])
+local used = tonumber(redis.call('GET', KEYS[1]) or '0')
+redis.call('SET', KEYS[1], math.max(used - amount, 0), 'KEEPTTL')
+redis.call('DEL', KEYS[2])
+return 1
+"""
+
+_RECONCILE_LUA = """
+local prior = redis.call('GET', KEYS[2])
+if not prior or prior ~= ARGV[1] then return 0 end
+local reserved = tonumber(ARGV[2])
+local keep = math.min(math.max(tonumber(ARGV[3]), 0), reserved)
+local used = tonumber(redis.call('GET', KEYS[1]) or '0')
+redis.call('SET', KEYS[1], math.max(used - (reserved - keep), 0), 'KEEPTTL')
+redis.call('SET', KEYS[2], ARGV[4] .. ':' .. keep, 'KEEPTTL')
 return 1
 """
 
@@ -59,6 +80,7 @@ async def authorize(user: dict, amount_micro: int, ref: str) -> tuple[bool, str 
             int(amount_micro),
             int(daily),
             _seconds_to_tomorrow(),
+            day,
         )
     except Exception:
         return False, "service spending ceiling unavailable"
@@ -72,3 +94,82 @@ async def authorize(user: dict, amount_micro: int, ref: str) -> tuple[bool, str 
         )
         return False, "service daily spending ceiling exceeded"
     return True, None
+
+
+def _parse_reservation(raw, fallback_day: str) -> tuple[str, int] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    value = str(raw)
+    if ":" in value:
+        day, amount = value.rsplit(":", 1)
+    else:
+        # Compatibility with reservations written before day binding.
+        day, amount = fallback_day, value
+    try:
+        return day, max(int(amount), 0)
+    except ValueError:
+        return None
+
+
+async def release(service_id: str | None, ref: str) -> bool:
+    """Release a service exposure reservation exactly once.
+
+    Failure is conservative: the stale reservation expires with its UTC-day
+    bucket instead of accidentally granting more service spend.
+    """
+    if not service_id:
+        return False
+    try:
+        from ..redis_client import get_redis
+
+        redis = get_redis()
+        ref_key = f"grid:service-spend-ref:{service_id}:{ref}"
+        fallback_day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        raw = await redis.get(ref_key)
+        parsed = _parse_reservation(raw, fallback_day)
+        if not parsed:
+            return False
+        day, amount = parsed
+        return bool(await redis.eval(
+            _RELEASE_LUA,
+            2,
+            f"grid:service-spend:{service_id}:{day}",
+            ref_key,
+            raw.decode() if isinstance(raw, bytes) else str(raw),
+            amount,
+        ))
+    except Exception:
+        return False
+
+
+async def reconcile(service_id: str | None, ref: str, keep_micro: int) -> bool:
+    """Reduce a service reservation to actual spend, idempotently."""
+    if not service_id:
+        return False
+    try:
+        from ..redis_client import get_redis
+
+        redis = get_redis()
+        ref_key = f"grid:service-spend-ref:{service_id}:{ref}"
+        fallback_day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        raw = await redis.get(ref_key)
+        parsed = _parse_reservation(raw, fallback_day)
+        if not parsed:
+            return False
+        day, reserved = parsed
+        keep = min(max(int(keep_micro), 0), reserved)
+        expected = raw.decode() if isinstance(raw, bytes) else str(raw)
+        return bool(await redis.eval(
+            _RECONCILE_LUA,
+            2,
+            f"grid:service-spend:{service_id}:{day}",
+            ref_key,
+            expected,
+            reserved,
+            keep,
+            day,
+        ))
+    except Exception:
+        return False

--- a/grid_api/services/tests/test_alerts.py
+++ b/grid_api/services/tests/test_alerts.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 AI Power Grid
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import httpx
+import pytest
+
+from grid_api import redis_client
+from grid_api.services import alerts
+
+
+def test_payload_redacts_and_excludes_sensitive_fields():
+    payload = alerts.build_payload(
+        "test",
+        "critical",
+        "contact person@example.com using grid-secret-value-1234567890",
+        {
+            "account": "safe-correlation-id",
+            "api_key": "must-not-appear",
+            "prompt": "must-not-appear",
+            "note": "mail me@example.com https://discord.com/api/webhooks/1/secret",
+        },
+    )
+    rendered = str(payload)
+    assert "person@example.com" not in rendered
+    assert "me@example.com" not in rendered
+    assert "must-not-appear" not in rendered
+    assert "/api/webhooks/1/secret" not in rendered
+    assert "safe-correlation-id" in rendered
+    assert payload["allowed_mentions"] == {"parse": []}
+
+
+def test_only_official_discord_webhooks_are_accepted():
+    assert alerts._valid_webhook("https://discord.com/api/webhooks/123/abc")
+    assert not alerts._valid_webhook("http://discord.com/api/webhooks/123/abc")
+    assert not alerts._valid_webhook("https://example.com/api/webhooks/123/abc")
+    assert not alerts._valid_webhook("https://discord.com/channels/123")
+
+
+@pytest.mark.asyncio
+async def test_delivery_posts_redacted_payload_without_leaking_url(monkeypatch):
+    seen = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(204)
+
+    old_client = alerts._client
+    alerts._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        payload = alerts.build_payload("signup", "success", "new account", {"account": "abc"})
+        ok = await alerts._deliver("https://discord.com/api/webhooks/123/redacted-test", payload)
+    finally:
+        await alerts._client.aclose()
+        alerts._client = old_client
+    assert ok is True
+    assert len(seen) == 1
+    assert seen[0].headers["content-type"].startswith("application/json")
+
+
+@pytest.mark.asyncio
+async def test_distributed_dedupe_claims_once_and_releases_failed_delivery(monkeypatch):
+    class FakeRedis:
+        def __init__(self):
+            self.values = {}
+
+        async def set(self, key, value, *, ex, nx):
+            if nx and key in self.values:
+                return False
+            self.values[key] = value
+            return True
+
+        async def eval(self, _script, _keys, key, token):
+            if self.values.get(key) == token:
+                del self.values[key]
+                return 1
+            return 0
+
+    fake = FakeRedis()
+    monkeypatch.setattr(redis_client, "get_redis", lambda: fake)
+    first = await alerts._claim_distributed("same-event", 60)
+    assert first
+    assert await alerts._claim_distributed("same-event", 60) is None
+    await alerts._release_distributed(first)
+    assert await alerts._claim_distributed("same-event", 60)

--- a/grid_api/services/tests/test_canary_credit_cli.py
+++ b/grid_api/services/tests/test_canary_credit_cli.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 AI Power Grid
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+
+from scripts.grant_canary_credit import amount_to_micro
+
+
+def test_canary_amount_is_exact_and_bounded():
+    assert amount_to_micro("0.000001") == 1
+    assert amount_to_micro("10") == 10_000_000
+    with pytest.raises(ValueError):
+        amount_to_micro("0")
+    with pytest.raises(ValueError):
+        amount_to_micro("10.000001")
+    with pytest.raises(ValueError):
+        amount_to_micro("1.0000001")

--- a/grid_api/services/tests/test_credits.py
+++ b/grid_api/services/tests/test_credits.py
@@ -4,7 +4,7 @@
 """Tests for the dark-shipped credit metering path.
 
 These exercise the no-DB branches of `charge_request` — the only ones the live
-request path hits while GRID_CHARGING_ENABLED=0 — so they need no Postgres:
+request path hits while GRID_CHARGING_MODE=off — so they need no Postgres:
 
 * dry-run (charging disabled): reports `would_charge`, never debits.
 * free (unpriced model): 0, no account lookup.
@@ -20,6 +20,44 @@ from grid_api.services import credits, pricing
 
 
 PRICED_MODEL = "deepseek-v4-flash"  # in the price book → quote > 0
+
+
+def test_charging_policy_modes(monkeypatch):
+    user = {"account_id": "A-1", "service_id": "Gallery"}
+
+    monkeypatch.setattr(credits, "_CHARGING_MODE_ENV", "off")
+    assert credits.charging_enabled_for(user, PRICED_MODEL) is False
+
+    monkeypatch.setattr(credits, "_CHARGING_MODE_ENV", "on")
+    assert credits.charging_enabled_for({}, PRICED_MODEL) is True
+
+    monkeypatch.setattr(credits, "_CHARGING_MODE_ENV", "allowlist")
+    monkeypatch.setattr(credits, "CHARGING_ALLOW_ACCOUNTS", frozenset({"a-1"}))
+    monkeypatch.setattr(credits, "CHARGING_ALLOW_SERVICES", frozenset())
+    monkeypatch.setattr(credits, "CHARGING_ALLOW_MODELS", frozenset())
+    assert credits.charging_enabled_for(user, PRICED_MODEL) is True
+    assert credits.charging_enabled_for({"account_id": "a-2"}, PRICED_MODEL) is False
+
+    monkeypatch.setattr(credits, "CHARGING_ALLOW_MODELS", frozenset({PRICED_MODEL}))
+    assert credits.charging_enabled_for(user, PRICED_MODEL) is True
+    assert credits.charging_enabled_for(user, "other-model") is False
+    # Account status can report cohort membership without choosing a model.
+    assert credits.charging_enabled_for(user) is True
+
+
+def test_legacy_boolean_remains_emergency_compatible(monkeypatch):
+    monkeypatch.setattr(credits, "_CHARGING_MODE_ENV", "")
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", False)
+    assert credits.charging_mode() == "off"
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    assert credits.charging_mode() == "on"
+
+
+def test_invalid_charging_mode_fails_closed(monkeypatch):
+    monkeypatch.setattr(credits, "_CHARGING_MODE_ENV", "surprise")
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    assert credits.charging_mode() == "off"
+    assert credits.charging_enabled_for({"account_id": "a-1"}, PRICED_MODEL) is False
 
 
 @pytest.mark.asyncio

--- a/grid_api/services/tests/test_credits_billing.py
+++ b/grid_api/services/tests/test_credits_billing.py
@@ -97,6 +97,32 @@ async def test_authorize_blocks_insufficient(db, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_insufficient_credit_releases_service_exposure(db, monkeypatch):
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    released = []
+
+    async def authorize(_user, _amount, _ref):
+        return True, None
+
+    async def release(service_id, ref):
+        released.append((service_id, ref))
+        return True
+
+    monkeypatch.setattr(credits.service_limits, "authorize", authorize)
+    monkeypatch.setattr(credits.service_limits, "release", release)
+    aid = uuid.uuid4()
+    await credits.credit(aid, 5, "topup", ref="seed-service")
+    user = {
+        "account_id": aid,
+        "service_id": "gallery",
+        "service_limits": {"per_request_micro": 1_000_000, "daily_micro": 10_000_000},
+    }
+    auth = await credits.authorize_request(user, PRICED, 1000, 1000, "job-service-402")
+    assert auth["status"] == "insufficient"
+    assert released == [("gallery", "job-service-402")]
+
+
+@pytest.mark.asyncio
 async def test_authorize_unpriced_blocked_in_enforce(db, monkeypatch):
     monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
     auth = await credits.authorize_request(
@@ -104,6 +130,17 @@ async def test_authorize_unpriced_blocked_in_enforce(db, monkeypatch):
     )
     assert auth["ok"] is False
     assert auth["status"] == "unpriced"
+
+
+@pytest.mark.asyncio
+async def test_authorize_wrong_modality_blocked_in_enforce(db, monkeypatch):
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    auth = await credits.authorize_request(
+        {"account_id": uuid.uuid4()}, VID, 10, 10, "job-video-as-text"
+    )
+    assert auth["ok"] is False
+    assert auth["status"] == "unpriced"
+    assert "text price" in auth["reason"]
 
 
 @pytest.mark.asyncio
@@ -170,6 +207,45 @@ async def test_authorize_media_unpriced_blocked(db, monkeypatch):
     monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
     auth = await credits.authorize_media(uuid.uuid4(), "no-such-image-xyz", "image", 1, None, "mjob3")
     assert auth["ok"] is False and auth["status"] == "unpriced"
+
+
+@pytest.mark.asyncio
+async def test_authorize_media_wrong_modality_blocked(db, monkeypatch):
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    auth = await credits.authorize_media(
+        uuid.uuid4(), VID, "image", 1, None, "mjob-video-as-image"
+    )
+    assert auth["ok"] is False and auth["status"] == "unpriced"
+    assert "image price" in auth["reason"]
+
+
+def test_live_model_names_have_explicit_modality_prices():
+    assert pricing.is_priced_for("deepseek-v4-flash-nvfp4", "text")
+    assert pricing.is_priced_for("qwen3-27b", "text")
+    assert pricing.is_priced_for("Smollm-135m", "text")
+    assert pricing.is_priced_for("Krea 2 Turbo", "image")
+    assert pricing.is_priced_for("LTX Director 2.0", "video")
+    assert pricing.is_priced_for("LTX-2.3 Audio", "video")
+    assert pricing.is_priced_for("ace-step-v1.5-xl-turbo", "audio")
+    assert not pricing.is_priced_for("LTX-2.3", "image")
+    assert not pricing.is_priced_for("Krea 2 Turbo", "video")
+
+
+def test_positive_price_never_rounds_to_free():
+    assert pricing.quote_text("Smollm-135m", 1, 0) == 1
+
+
+@pytest.mark.asyncio
+async def test_tiny_positive_text_reserve_never_rounds_to_free(db, monkeypatch):
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    aid = uuid.uuid4()
+    await credits.credit(aid, 10, "topup", ref="tiny-seed")
+    auth = await credits.authorize_request(
+        {"account_id": aid}, "Smollm-135m", 1, 0, "tiny-job",
+    )
+    assert auth["ok"] is True
+    assert auth["status"] == "ok"
+    assert auth["reserved"] == 1
 
 
 @pytest.mark.asyncio

--- a/grid_api/services/tests/test_credits_billing.py
+++ b/grid_api/services/tests/test_credits_billing.py
@@ -74,6 +74,28 @@ async def test_credit_idempotent_on_ref(db):
 
 
 @pytest.mark.asyncio
+async def test_billing_health_detects_balance_ledger_drift(db):
+    aid = uuid.uuid4()
+    await credits.credit(aid, 5000, "topup", ref="health-seed")
+    healthy = await credits.billing_health()
+    assert healthy["ok"] is True
+    assert healthy["balance_total_micro"] == healthy["ledger_total_micro"] == 5000
+
+    from grid_api.v2.schema import credits as credits_table
+
+    async with await database.new_session() as session:
+        await session.execute(
+            credits_table.update()
+            .where(credits_table.c.account_id == aid)
+            .values(balance_micro=4999),
+        )
+        await session.commit()
+    drifted = await credits.billing_health()
+    assert drifted["ok"] is False
+    assert drifted["balance_delta_micro"] == -1
+
+
+@pytest.mark.asyncio
 async def test_debit_idempotent_and_overdraft_safe(db):
     aid = uuid.uuid4()
     await credits.credit(aid, 1000, "topup", ref="seed")

--- a/grid_api/services/tests/test_discount_eth.py
+++ b/grid_api/services/tests/test_discount_eth.py
@@ -65,7 +65,7 @@ async def test_charge_request_dry_run_reflects_discount(monkeypatch):
     user = {"account_id": "00000000-0000-0000-0000-000000000001", "wallet": WALLET}
     out = await credits.charge_request(user, PRICED_MODEL, 1000, 2000, "job-disc-1")
     assert out["status"] == "dry_run"
-    assert out["would_charge"] == full * 7500 // 10_000  # 25% off
+    assert out["would_charge"] == (full * 7500 + 9_999) // 10_000  # 25% off, rounded up
 
 
 # ── ETH deposit pricing (Chainlink parse + credit math) ─────────────────────

--- a/grid_api/services/tests/test_media_contract.py
+++ b/grid_api/services/tests/test_media_contract.py
@@ -55,3 +55,29 @@ async def test_live_media_rejects_legacy_no_account_before_dispatch(monkeypatch)
         )
     assert exc.value.status_code == 402
     assert "v2 account" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_live_media_bills_recipe_baked_duration(monkeypatch):
+    recipes.register_recipe("0xbilling-duration", "billing-duration", {
+        "_grid": {
+            "modelName": "billing-duration",
+            "jobType": "video",
+            "vars": {"seconds": "9.inputs.value", "seed": "3.inputs.seed"},
+        },
+        "3": {"inputs": {"seed": 0}},
+        "9": {"inputs": {"value": 10}},
+    })
+    observed = {}
+
+    async def authorize(_account_id, _model, _job_type, _n, seconds, _job_id, **_kwargs):
+        observed["seconds"] = seconds
+        return {"ok": False, "reserved": 0, "reason": "stop before dispatch"}
+
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    monkeypatch.setattr(credits, "authorize_media", authorize)
+    with pytest.raises(HTTPException):
+        await media.submit_and_wait(
+            "billing-duration", "video", {"n": 1}, 1, account_id="account",
+        )
+    assert observed["seconds"] == 10

--- a/grid_api/services/tests/test_native_service_auth.py
+++ b/grid_api/services/tests/test_native_service_auth.py
@@ -199,15 +199,33 @@ async def test_service_creation_is_atomic_on_duplicate_id(db):
 class _LimitRedis:
     def __init__(self):
         self.used = 0
-        self.refs: set[str] = set()
+        self.refs: dict[str, str] = {}
 
-    async def eval(self, _script, _key_count, _spend_key, ref_key, amount, cap, _ttl):
+    async def get(self, key):
+        return self.refs.get(key)
+
+    async def eval(self, script, _key_count, _spend_key, ref_key, *args):
+        if script == service_limits._RELEASE_LUA:
+            expected, amount = args
+            if self.refs.get(ref_key) != expected:
+                return 0
+            self.used = max(self.used - int(amount), 0)
+            del self.refs[ref_key]
+            return 1
+        if script == service_limits._RECONCILE_LUA:
+            expected, reserved, keep, day = args
+            if self.refs.get(ref_key) != expected:
+                return 0
+            self.used = max(self.used - (int(reserved) - int(keep)), 0)
+            self.refs[ref_key] = f"{day}:{keep}"
+            return 1
+        amount, cap, _ttl, day = args
         if ref_key in self.refs:
             return 1
         if int(cap) > 0 and self.used + int(amount) > int(cap):
             return 0
         self.used += int(amount)
-        self.refs.add(ref_key)
+        self.refs[ref_key] = f"{day}:{amount}"
         return 1
 
 
@@ -228,7 +246,18 @@ async def test_service_spending_limits_are_idempotent_and_fail_closed(db, monkey
     assert await service_limits.authorize(user, 500, "job-1") == (True, None)
     assert await service_limits.authorize(user, 500, "job-1") == (True, None)
     assert redis.used == 500
+    assert await service_limits.reconcile("limits-test", "job-1", 200) is True
+    assert await service_limits.reconcile("limits-test", "job-1", 200) is True
+    assert redis.used == 200
+    assert await service_limits.authorize(user, 300, "job-release") == (True, None)
+    assert redis.used == 500
+    assert await service_limits.release("limits-test", "job-release") is True
+    assert await service_limits.release("limits-test", "job-release") is False
+    assert redis.used == 200
     allowed, reason = await service_limits.authorize(user, 501, "job-2")
+    assert allowed and reason is None
+    assert redis.used == 701
+    allowed, reason = await service_limits.authorize(user, 300, "job-over")
     assert not allowed and "daily" in reason
     allowed, reason = await service_limits.authorize(user, 601, "job-3")
     assert not allowed and "per-request" in reason

--- a/grid_api/services/tests/test_native_service_auth.py
+++ b/grid_api/services/tests/test_native_service_auth.py
@@ -17,7 +17,7 @@ from starlette.requests import Request
 
 from grid_api import database
 from grid_api.routers import accounts as accounts_router
-from grid_api.services import accounts, quota, service_limits, user_tokens
+from grid_api.services import accounts, alerts, quota, service_limits, user_tokens
 from grid_api.v2.schema import accounts as accounts_table
 from grid_api.v2.schema import metadata
 from grid_api.v2.schema import service_clients as service_clients_table
@@ -75,6 +75,31 @@ async def test_service_exchange_is_namespaced_and_short_lived(db):
         authorization=None,
     )
     assert same["account_id"] == result["account_id"]
+
+
+@pytest.mark.asyncio
+async def test_account_creation_emits_redacted_signup_alert(db, monkeypatch):
+    events = []
+    monkeypatch.setattr(alerts, "emit", lambda *args, **kwargs: events.append((args, kwargs)) or True)
+
+    account, _ = await accounts.create_account(
+        username="Private Person",
+        email="private@example.com",
+        oauth_sub="google-private-subject",
+        email_verified=True,
+        issue_initial_key=False,
+        grant_verified_welcome=False,
+    )
+
+    assert len(events) == 1
+    args, kwargs = events[0]
+    assert args[:3] == ("account_created", "success", "A new Grid account was created.")
+    rendered = str(kwargs)
+    assert "private@example.com" not in rendered
+    assert "google-private-subject" not in rendered
+    assert "Private Person" not in rendered
+    assert kwargs["fields"]["provider"] == "google"
+    assert kwargs["fields"]["account"] == alerts.opaque_id(account["id"])
 
 
 def test_user_token_signature_audience_expiry_and_step_up(monkeypatch):

--- a/grid_api/services/tests/test_quota.py
+++ b/grid_api/services/tests/test_quota.py
@@ -62,6 +62,40 @@ async def test_paid_user_is_not_metered(fake_redis, monkeypatch):
     assert fake_redis.store == {}
 
 
+@pytest.mark.asyncio
+async def test_positive_purchased_balance_is_not_metered(fake_redis, monkeypatch):
+    async def has_credit(user):
+        return user.get("account_id") == "paid-account"
+
+    monkeypatch.setattr("grid_api.services.credits.has_credit", has_credit)
+    user = {"id": 1, "account_id": "paid-account", "quota_exempt": False}
+    await quota.check_and_consume(user)
+    assert await quota.remaining(user) is None
+    assert fake_redis.store == {}
+
+
+@pytest.mark.asyncio
+async def test_zero_purchased_balance_stays_in_free_quota(fake_redis, monkeypatch):
+    async def has_credit(_user):
+        return False
+
+    monkeypatch.setattr("grid_api.services.credits.has_credit", has_credit)
+    user = {"id": 1, "account_id": "free-account", "quota_exempt": False}
+    await quota.check_and_consume(user)
+    assert len(fake_redis.store) == 1
+
+
+@pytest.mark.asyncio
+async def test_balance_lookup_failure_does_not_grant_paid_bypass(fake_redis, monkeypatch):
+    async def has_credit(_user):
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr("grid_api.services.credits.has_credit", has_credit)
+    user = {"id": 1, "account_id": "unknown-account", "quota_exempt": False}
+    await quota.check_and_consume(user)
+    assert len(fake_redis.store) == 1
+
+
 def test_is_paid_uses_explicit_policy():
     assert quota.is_paid({"quota_exempt": True}) is True
     assert quota.is_paid({"quota_exempt": False}) is False

--- a/grid_api/services/tests/test_recipes.py
+++ b/grid_api/services/tests/test_recipes.py
@@ -122,6 +122,22 @@ def test_resolve_for_model_by_name_and_fallback():
     print("ok: resolve_for_model by name + legacy fallback")
 
 
+def test_baked_default_uses_selected_recipe_graph():
+    _clear()
+    recipes.register_recipe("0xdefault-seconds", "duration-default", {
+        "_grid": {
+            "modelName": "duration-default",
+            "jobType": "video",
+            "vars": {"seconds": "9.inputs.value", "seed": "3.inputs.seed"},
+        },
+        "3": {"inputs": {"seed": 0}},
+        "9": {"inputs": {"value": 10}},
+    })
+    assert recipes.baked_default_for_model("duration-default", "seconds") == 10
+    assert recipes.baked_default_for_model("duration-default", "width") is None
+    assert recipes.baked_default_for_model("missing", "seconds") is None
+
+
 def test_bad_slot_path_rejected():
     _clear()
     recipes.register_recipe("0xbad", "bad", {"_grid": {"vars": {"prompt": "nope.inputs.text"}},

--- a/grid_api/services/tests/test_reservation_lifecycle.py
+++ b/grid_api/services/tests/test_reservation_lifecycle.py
@@ -86,6 +86,23 @@ async def test_authorize_records_reservation_atomically_and_idempotently(db, mon
 
 
 @pytest.mark.asyncio
+async def test_existing_hold_settles_after_new_charging_is_disabled(db, monkeypatch):
+    """The kill switch stops new holds; it must not corrupt in-flight ones."""
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    aid = uuid.uuid4()
+    await credits.credit(aid, 10_000_000, "topup", ref="seed-kill-switch")
+    reserved = await _reserve(aid, "job-kill-switch", prompt=1000, mx=1000)
+    assert reserved > 0
+
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", False)
+    await credits.settle_job("job-kill-switch", completion_tokens=10)
+
+    actual = pricing.quote_text(PRICED, 1000, 10)
+    assert await _reservation_status("job-kill-switch") == "settled"
+    assert await credits.get_balance(aid) == 10_000_000 - actual
+
+
+@pytest.mark.asyncio
 async def test_authorize_rolls_back_debit_if_reservation_write_fails(db, monkeypatch):
     monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
     aid = uuid.uuid4()

--- a/grid_api/services/tests/test_reservation_lifecycle.py
+++ b/grid_api/services/tests/test_reservation_lifecycle.py
@@ -125,6 +125,36 @@ async def test_settle_refunds_unused_remainder(db, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_settle_reconciles_service_exposure_to_actual(db, monkeypatch):
+    monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
+    reconciled = []
+
+    async def authorize(_user, _amount, _ref):
+        return True, None
+
+    async def reconcile(service_id, ref, keep_micro):
+        reconciled.append((service_id, ref, keep_micro))
+        return True
+
+    monkeypatch.setattr(credits.service_limits, "authorize", authorize)
+    monkeypatch.setattr(credits.service_limits, "reconcile", reconcile)
+    aid = uuid.uuid4()
+    await credits.credit(aid, 10_000_000, "topup", ref="service-seed")
+    user = {
+        "account_id": aid,
+        "service_id": "chat-frontend",
+        "service_limits": {"per_request_micro": 1_000_000, "daily_micro": 10_000_000},
+    }
+    auth = await credits.authorize_request(
+        user, PRICED, 1000, 1000, "service-job", record_reservation=True,
+    )
+    assert auth["ok"]
+    await credits.settle_job("service-job", 100)
+    actual = pricing.quote_text(PRICED, 1000, 100)
+    assert reconciled == [("chat-frontend", "service-job", actual)]
+
+
+@pytest.mark.asyncio
 async def test_settlement_uses_reservation_time_price_snapshot(db, monkeypatch):
     monkeypatch.setattr(credits, "CHARGING_ENABLED", True)
     aid = uuid.uuid4()

--- a/grid_api/v2/schema.py
+++ b/grid_api/v2/schema.py
@@ -412,7 +412,7 @@ ledger = sa.Table(
 # A USDC deposit credits 1:1 (micro-USD); a completion debits per `pricing`. The
 # balance is a cache of the ledger sum — `grid_credit_ledger` is the truth and
 # makes every credit/debit idempotent (unique `ref`). See services/credits.py.
-# Ships dark (GRID_CHARGING_ENABLED=0): the request path only logs would-charge.
+# Ships dark (GRID_CHARGING_MODE=off): demand paths only log would-charge.
 
 credits = sa.Table(
     "grid_credits",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
     "SQLAlchemy~=2.0.35",
+    "greenlet>=3.1.0",
     "asyncpg>=0.30.0",
     "alembic>=1.13.0",
     "redis>=5.0.0",

--- a/requirements-grid.txt
+++ b/requirements-grid.txt
@@ -5,6 +5,7 @@
 fastapi>=0.115.0
 uvicorn[standard]>=0.34.0
 SQLAlchemy~=2.0.35
+greenlet>=3.1.0
 asyncpg>=0.30.0
 alembic>=1.13.0
 redis>=5.0.0

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -22,6 +22,8 @@ account provisioning tools, and an incomplete testnet model-registry helper.
   moving its account balance.
 - `rotate_service_key.py` - atomically revokes a service's old keys and prints
   one replacement key exactly once.
+- `grant_canary_credit.py` - dry-run-by-default, capped operator credit for one
+  allowlisted demand-billing canary.
 
 ## Local Contracts
 

--- a/scripts/grant_canary_credit.py
+++ b/scripts/grant_canary_credit.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 AI Power Grid
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Grant at most $10 of idempotent operator credit to one billing canary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from uuid import UUID
+
+import sqlalchemy as sa
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from grid_api.database import close_database, init_database, new_session
+from grid_api.services import alerts, credits
+from grid_api.v2.schema import accounts as accounts_table
+
+_MAX_CANARY_MICRO = 10_000_000
+
+
+def amount_to_micro(raw: str) -> int:
+    try:
+        amount = Decimal(raw)
+    except InvalidOperation as exc:
+        raise ValueError("amount must be a decimal USD value") from exc
+    micro = amount * 1_000_000
+    if micro != micro.to_integral_value():
+        raise ValueError("amount supports at most six decimal places")
+    value = int(micro)
+    if value <= 0 or value > _MAX_CANARY_MICRO:
+        raise ValueError("canary amount must be greater than $0 and no more than $10")
+    return value
+
+
+async def _run(args) -> None:
+    account_id = UUID(args.account_id)
+    amount_micro = amount_to_micro(args.amount_usd)
+    if not args.ref.startswith("canary:") or len(args.ref) > 120:
+        raise ValueError("ref must be a stable canary:* idempotency key of at most 120 characters")
+    if not args.apply:
+        print(f"dry_run=true account_id={account_id} amount_micro={amount_micro} ref={args.ref}")
+        return
+
+    await alerts.start()
+    await init_database()
+    try:
+        async with await new_session() as session:
+            exists = await session.scalar(
+                sa.select(accounts_table.c.id).where(accounts_table.c.id == account_id),
+            )
+        if not exists:
+            raise ValueError("account does not exist")
+        applied = await credits.credit(
+            account_id,
+            amount_micro,
+            reason="operator_canary",
+            ref=args.ref,
+        )
+        balance = await credits.get_balance(account_id)
+        alerts.emit(
+            "canary_credit_granted",
+            "success",
+            "Operator credit is available for a supervised billing canary.",
+            fields={
+                "account": alerts.opaque_id(account_id),
+                "amount_micro": amount_micro,
+                "applied": applied,
+                "balance_micro": balance,
+            },
+            dedupe_key=f"canary-credit:{args.ref}",
+        )
+        await alerts.flush()
+    finally:
+        await close_database()
+        await alerts.stop()
+    print(
+        f"applied={str(applied).lower()} account_id={account_id} "
+        f"amount_micro={amount_micro} balance_micro={balance}",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--amount-usd", required=True)
+    parser.add_argument("--ref", required=True, help="Stable idempotency key, e.g. canary:2026-07-28")
+    parser.add_argument("--apply", action="store_true", help="Actually move value; default is dry-run")
+    args = parser.parse_args()
+    try:
+        asyncio.run(_run(args))
+    except (ValueError, TypeError) as exc:
+        parser.error(str(exc))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add account/service allowlisted charging rollout with fail-closed pricing
- preserve settlement/refunds for in-flight holds after the charging kill switch
- add privacy-redacted, rate-limited Discord operations alerts and billing invariants
- add a capped idempotent canary-credit tool and launch runbook
- enforce Alembic parity and real Postgres money-path races in CI

## Verification
- 343 Grid tests passed against fresh Postgres 16
- Alembic upgrade/check clean through migration 0015
- 14 real Postgres concurrency/lifecycle tests passed
- pip check and pip-audit clean
- Bandit and gitleaks patch scans clean

Charging remains dark by default (`GRID_CHARGING_MODE=off`).