### PR TITLE
Suppress credential-bearing HTTP transport logs

### DIFF
--- a/grid_api/services/alerts.py
+++ b/grid_api/services/alerts.py
@@ -127,9 +127,16 @@ def _configured_url() -> str:
     return secret.get_secret_value().strip() if secret else ""
 
 
+def _harden_transport_logging() -> None:
+    """Prevent HTTP client request logs from printing credential-bearing URLs."""
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+
 async def start() -> None:
     """Start the delivery worker. Safe and idempotent."""
     global _queue, _worker_task, _client
+    _harden_transport_logging()
     if _worker_task and not _worker_task.done():
         return
     url = _configured_url()

--- a/grid_api/services/tests/test_alerts.py
+++ b/grid_api/services/tests/test_alerts.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 AI Power Grid
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import logging
+
 import httpx
 import pytest
 
@@ -34,6 +36,22 @@ def test_only_official_discord_webhooks_are_accepted():
     assert not alerts._valid_webhook("http://discord.com/api/webhooks/123/abc")
     assert not alerts._valid_webhook("https://example.com/api/webhooks/123/abc")
     assert not alerts._valid_webhook("https://discord.com/channels/123")
+
+
+def test_transport_request_logs_are_suppressed():
+    httpx_logger = logging.getLogger("httpx")
+    httpcore_logger = logging.getLogger("httpcore")
+    old_httpx = httpx_logger.level
+    old_httpcore = httpcore_logger.level
+    try:
+        httpx_logger.setLevel("INFO")
+        httpcore_logger.setLevel("INFO")
+        alerts._harden_transport_logging()
+        assert httpx_logger.level >= logging.WARNING
+        assert httpcore_logger.level >= logging.WARNING
+    finally:
+        httpx_logger.setLevel(old_httpx)
+        httpcore_logger.setLevel(old_httpcore)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- raise `httpx` and `httpcore` transport logging to WARNING before alert delivery starts
- prevent Discord webhook tokens from appearing in request-completed INFO logs
- add a regression test for both transport loggers

## Verification
- 339 tests passed, 11 skipped
- focused alert tests: 5 passed
- Ruff, diff check, and gitleaks patch scan clean