### PR TITLE
billing: retry lagging deposit receipts

### DIFF
--- a/grid_api/services/AGENTS.md
+++ b/grid_api/services/AGENTS.md
@@ -100,7 +100,9 @@ content sanitization, and reward settlement.
   paired append-only ledger entries.
 - Deposit senders must match a verified wallet identity on the canonical
   account. Never accept a client-supplied funding address without checking its
-  verified identity hash.
+  verified identity hash. A transaction or receipt that the configured RPC has
+  not seen yet is retryable (`425`), not an invalid claim; clients must retry
+  the same transaction hash and must never resend value to recover credit.
 - Service keys remain long-lived backend credentials but cannot manage user
   accounts. Global Google/SIWE proof is verified by Core; app delegation is
   namespaced to one service and receives bounded inference authority.

--- a/grid_api/services/deposits.py
+++ b/grid_api/services/deposits.py
@@ -321,7 +321,10 @@ async def _confirmed_transaction(tx_hash: str, asset: str) -> tuple[dict, dict, 
         )
         raise HTTPException(502, detail="Could not reach Base to verify the transaction.")
     if not tx or not receipt:
-        raise HTTPException(400, detail="Transaction not found or not yet mined.")
+        raise HTTPException(
+            425,
+            detail="Transaction not found or not yet visible. Retry shortly.",
+        )
     if receipt.get("status") not in ("0x1", 1):
         raise HTTPException(400, detail="Transaction failed on-chain.")
     block_number = int(receipt["blockNumber"], 16)

--- a/grid_api/services/tests/test_deposits.py
+++ b/grid_api/services/tests/test_deposits.py
@@ -279,6 +279,40 @@ async def test_claim_rejects_rpc_on_the_wrong_chain(db, funding, monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("missing_method", "missing_value"),
+    [
+        ("eth_getTransactionByHash", None),
+        ("eth_getTransactionReceipt", None),
+    ],
+)
+async def test_claim_retries_when_transaction_is_not_yet_visible(
+    db,
+    funding,
+    monkeypatch,
+    missing_method,
+    missing_value,
+):
+    rpc = _rpc_for(USDC, 5_000_000)
+
+    async def lagging_rpc(method, params):
+        if method == missing_method:
+            return missing_value
+        return await rpc(method, params)
+
+    monkeypatch.setattr(deposits, "_rpc", lagging_rpc)
+    with pytest.raises(HTTPException) as exc:
+        await deposits.verify_and_credit(
+            TX,
+            {"account_id": db, "wallet": WALLET},
+        )
+    assert exc.value.status_code == 425
+    assert "Retry shortly" in exc.value.detail
+    assert await credits.get_balance(db) == 0
+    assert await _deposit_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_aipg_claim_uses_epoch_haircut_and_records_provenance(db, funding, monkeypatch):
     # 10,000 AIPG at $0.002, less 3% = $19.40.
     amount = 10_000 * 10**18


### PR DESCRIPTION
## Summary
- classify Base RPC transaction/receipt visibility lag as retryable HTTP 425
- keep failed and malformed claims as hard failures
- cover missing transaction and missing receipt without credit writes

## Verification
- `PYTHONPATH=. .venv/bin/pytest -q grid_api` (373 passed, 8 skipped)
- fatal ruff checks
- `git diff --check`