### PR TITLE
docs: separate account source readiness from live parity

### DIFF
--- a/docs/architecture/DEMAND_SIDE_AUDIT_BRIEF.md
+++ b/docs/architecture/DEMAND_SIDE_AUDIT_BRIEF.md
@@ -204,14 +204,15 @@ Core remains the sole charging-mode authority; frontend deployments cannot
 turn billing on.
 
 Current source verification on 2026-08-21 is stronger than the deployed
-candidate but is not production evidence: Core main passes 89 focused identity,
+candidate but is not production evidence: Core main passes 90 focused identity,
 credit, reservation, pricing, and canary-audit tests (7 real-Postgres tests
 skipped in that local run); Art passes 90 frontend tests, the complete Go suite,
 its production build, and nine Playwright journeys; Music passes lint,
 typecheck, production build, and its canonical-account quote/auth smoke; Console
 passes lint, formatting, production build, and its account-mismatch smoke; Chat
-passes 18 focused delegated-identity tests. These results prove the checked-in
-contracts, not a live cross-product canary.
+passes 56 focused permission, wallet-identity, delegation, account, and quote
+tests. These results prove the checked-in contracts, not a live cross-product
+canary.
 
 The production canary has three successful, durable settlements on the selected
 canonical account: delegated Chat text, delegated Art Krea image, and delegated

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -265,16 +265,17 @@ and the 24-hour unchanged-cohort window remain unproven. The remaining canary
 balance is below the currently selected model's minimum charge; further real
 work requires deliberate funding approval.
 
-### 25. One canonical account and balance - Implemented
+### 25. One canonical account and balance - Source-complete, live parity pending
 
 Core owns canonical identity links, aliases, three credit pockets, and bounded
 service delegation. Focused Core, Chat, Art, Music, and Console tests prove
 delegated tokens and reject account mismatches. Google and wallet proof can
 merge without rewriting historical ledgers. Every auth change still requires a
 cross-product live canary because partial deployments have caused outages. The
-required live four-surface Google run and separate wallet run have not yet been
-captured as one retained, `no-store` receipt set, so code-level completion must
-not be mistaken for production-parity evidence.
+required live Google run and separate wallet run across Console, Chat, Art,
+Music, and direct API use have not yet been captured as retained, `no-store`
+receipt sets, so code-level completion must not be mistaken for
+production-parity evidence.
 
 ### 26. Explicit owner-worker reward policy - Open, payout-backlog
 


### PR DESCRIPTION
## Summary
- mark canonical accounts source-complete while retaining the live parity gate
- require retained Google and wallet receipt sets across every product and direct API use
- refresh focused source-test evidence without changing the immutable production record

## Verification
- git diff --check
- no runtime or deployment changes