### PR TITLE
ci(security): scan complete Core history

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,6 +13,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Install checksum-verified Gitleaks
         shell: bash
         run: |
@@ -24,6 +26,8 @@ jobs:
           sudo install /tmp/gitleaks /usr/local/bin/gitleaks
       - name: Scan tracked source tree
         run: gitleaks detect --source . --no-git --config .gitleaks.toml --redact --verbose
+      - name: Scan complete reachable history
+        run: gitleaks git . --log-opts=HEAD --config .gitleaks.toml --redact --verbose
 
   infra-strings:
     runs-on: ubuntu-22.04

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,18 @@
+# Reviewed 2026-08-21. Exact historical fingerprints only.
+#
+# The API-key-shaped values below belong to the retired upstream Horde history.
+# Every distinct historical credential in the critical-repository audit was
+# rejected by the production account endpoint with HTTP 401. The remaining
+# entries are retired bucket/developer-path disclosures. This file records no
+# secret value and must never contain a broad rule, path, or regex exclusion.
+2a8219045f1c5b00d8188df543d2a653bc6596c5:docs/SYSTEM_SWEEP_2026-07-01.md:aipg-local-dev-path:91
+2a8219045f1c5b00d8188df543d2a653bc6596c5:docs/SYSTEM_SWEEP_2026-07-01.md:aipg-r2-bucket:13
+2fafcf40227390c4b0b6ddf82b93d6fabd2819dd:clientData_template.py:generic-api-key:9
+43a602e48f35f9ae29150b28ed0ff2b3486b16ee:tests/test_alchemy.py:generic-api-key:10
+43a602e48f35f9ae29150b28ed0ff2b3486b16ee:tests/test_image.py:generic-api-key:10
+43a602e48f35f9ae29150b28ed0ff2b3486b16ee:tests/test_text.py:generic-api-key:10
+8161c74b1c5cef937aeda0f7ef1cf1edb870e263:tests/test_alchemy.py:generic-api-key:9
+8161c74b1c5cef937aeda0f7ef1cf1edb870e263:tests/test_image.py:generic-api-key:9
+8161c74b1c5cef937aeda0f7ef1cf1edb870e263:tests/test_text.py:generic-api-key:9
+81ca4227e8f73bfd14045cb702f1404cbe7ee516:grid_api/services/storage.py:aipg-r2-bucket:43
+8c00255e8f91beddcfa9acf2371e4d3767596be9:test.py:generic-api-key:6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,10 @@ owning AGENTS.md and any affected parent Child DOX Index.
 - Root-owned files include `server.py`, `server_grid_api.py`, `requirements*.txt`,
   `requirements-grid.lock`, `pyproject.toml`, `Dockerfile`,
   `docker-compose.yaml`, root READMEs, assets, and one-off utility scripts.
-- `.github/workflows/secret-scan.yml` and `.gitleaks.toml` enforce
-  checksum-verified secret and operational-infrastructure scanning on pushes
-  and pull requests.
+- `.github/workflows/secret-scan.yml`, `.gitleaks.toml`, and
+  `.gitleaksignore` enforce checksum-verified tracked-tree and full reachable
+  history scanning on pushes and pull requests. Historical exceptions are
+  exact reviewed fingerprints, never broad path/rule exclusions.
 
 ## Local Contracts
 
@@ -95,7 +96,8 @@ owning AGENTS.md and any affected parent Child DOX Index.
 - For docs-only changes, run at least `git diff --check` and inspect the DOX
   chain for stale indexes.
 - Secret gate: `gitleaks detect --source . --no-git --config .gitleaks.toml
-  --redact` from a clean checkout.
+  --redact` followed by `gitleaks git . --log-opts=HEAD --config
+  .gitleaks.toml --redact` from a full clone.
 
 ## Child DOX Index
 


### PR DESCRIPTION
## What
- make the existing required gitleaks job fetch and scan complete reachable `HEAD` history
- baseline only eleven exact, reviewed default-branch fingerprints
- document the full-history verification contract in DOX

## Why
Tracked-tree scanning cannot detect credentials or operational metadata removed from `HEAD` but still recoverable from Git. Exact fingerprints preserve a clean enforced history gate without broad exclusions.

## Verification
- `gitleaks detect --source . --no-git --config .gitleaks.toml --redact`
- `gitleaks git . --log-opts=HEAD --config .gitleaks.toml --redact` (1,510 commits; no unreviewed findings)
- negative test: a new committed synthetic private-key pattern is rejected
- `git diff --check`

## Risk
CI-only. No production, credential, database, release, or deployment state changes. Future legitimate historical findings must be reviewed before merge instead of being silently ignored.