### PR TITLE
validators: add calibrated 32K and safe code probes

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -81,9 +81,18 @@ jobs:
           AIPG_RESTORE_RUN_AS_CURRENT_USER: '1'
         run: |
           alembic upgrade 0019
+          PGPASSWORD="$POSTGRES_PASS" psql \
+            --host=127.0.0.1 \
+            --username="$POSTGRES_USER" \
+            --dbname=grid_test \
+            --command='CREATE SCHEMA backup_excluded; CREATE TABLE backup_excluded.must_not_ship(id integer);'
           backup_dir="$RUNNER_TEMP/aipg-postgres-backup"
           AIPG_BACKUP_DIR="$backup_dir" scripts/backup_postgres.sh
           backup="$(find "$backup_dir" -maxdepth 1 -name 'grid-postgres-*.dump' -print -quit)"
+          if pg_restore --list "$backup" | grep -q 'backup_excluded'; then
+            echo 'backup unexpectedly contains a non-Grid schema' >&2
+            exit 1
+          fi
           AIPG_RESTORE_BACKUP="$backup" \
             AIPG_RESTORE_CANDIDATE="$GITHUB_WORKSPACE" \
             AIPG_RESTORE_PYTHON="$(command -v python)" \

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -64,6 +64,38 @@ jobs:
           -r requirements-grid.lock --require-hashes --no-deps --disable-pip
       - name: Retired runtime gate
         run: python scripts/check_retired_runtime.py
+      - name: Validate operations scripts
+        run: |
+          bash -n scripts/backup_postgres.sh scripts/prove_postgres_restore.sh
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client shellcheck
+          shellcheck -x scripts/backup_postgres.sh scripts/prove_postgres_restore.sh deploy/bootstrap.sh
+      - name: Backup and restored migration proof
+        env:
+          POSTGRES_USER: grid_test
+          POSTGRES_PASS: grid_test
+          POSTGRES_URL: 127.0.0.1:5432/grid_test
+          AIPG_RESTORE_ADMIN_USER: grid_test
+          AIPG_RESTORE_ADMIN_PASS: grid_test
+          AIPG_RESTORE_RUN_AS_CURRENT_USER: '1'
+        run: |
+          alembic upgrade 0019
+          PGPASSWORD="$POSTGRES_PASS" psql \
+            --host=127.0.0.1 \
+            --username="$POSTGRES_USER" \
+            --dbname=grid_test \
+            --command='CREATE SCHEMA backup_excluded; CREATE TABLE backup_excluded.must_not_ship(id integer);'
+          backup_dir="$RUNNER_TEMP/aipg-postgres-backup"
+          AIPG_BACKUP_DIR="$backup_dir" scripts/backup_postgres.sh
+          backup="$(find "$backup_dir" -maxdepth 1 -name 'grid-postgres-*.dump' -print -quit)"
+          if pg_restore --list "$backup" | grep -q 'backup_excluded'; then
+            echo 'backup unexpectedly contains a non-Grid schema' >&2
+            exit 1
+          fi
+          AIPG_RESTORE_BACKUP="$backup" \
+            AIPG_RESTORE_CANDIDATE="$GITHUB_WORKSPACE" \
+            AIPG_RESTORE_PYTHON="$(command -v python)" \
+            scripts/prove_postgres_restore.sh
       - name: Migration and schema parity
         run: |
           alembic upgrade head

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,9 @@ owning AGENTS.md and any affected parent Child DOX Index.
   `pip-audit -r requirements-grid.lock --require-hashes --no-deps --disable-pip`;
   investigate every skipped non-PyPI dependency separately.
 - Grid-focused: `pytest grid_api/`.
+- Deployment candidates must pass the PostgreSQL 16 backup/restore proof in
+  pull-request CI; this is part of the required `tests` context, not a
+  post-merge-only check.
 - Service units: `pytest grid_api/services/`.
 - Router billing/settlement coverage: `pytest grid_api/routers/`.
 - Legacy smoke tests live under `tests/` and may skip without external services.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -55,6 +55,12 @@ executes an immutable release selected through `/home/aipg/current`.
 - Validator probe leases must exceed the worker-response timeout and keep a
   small bounded retry budget. Do not make targeted validation an unlimited
   free-inference path.
+- `VALIDATOR_TEXT_GROUP_MIN_INTERVAL_SECONDS` limits creation of real text
+  workloads per worker/model (default one hour; Core enforces a five-minute
+  floor). `VALIDATOR_HISTORY_RETENTION_DAYS` and
+  `VALIDATOR_HISTORY_SWEEP_SECONDS` bound finalized assignment/group machinery;
+  signed attestations are preserved. Keep `env.template`, `config.py`, and the
+  validator runbook aligned when changing these controls.
 - Apply Alembic `0024` before code that issues media assignments; it adds the
   group execution lease and shared frozen-witness columns read by that path.
 - `VALIDATOR_MEDIA_PROBE_ENABLED` is not a standalone launch switch. Keep it off

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -81,7 +81,9 @@ sudo bash -c "set -a; source /etc/aipg/grid.env; set +a; \
   '$RELEASE/scripts/prove_postgres_restore.sh'"
 ```
 
-The proof verifies the checksum, restores into a generated
+The backup is intentionally scoped to the Grid-owned `public` schema; legacy
+and extension-owned schemas such as `cron` are not application state and are
+excluded. The proof verifies the checksum, restores into a generated
 `aipg_restore_proof_*` database, upgrades with the candidate, runs
 `alembic check`, compares current revision to the candidate head, and drops only
 that generated database. Review the output before enabling the timer with

--- a/deploy/env.template
+++ b/deploy/env.template
@@ -145,6 +145,13 @@ VALIDATOR_ATTESTATION_GRACE_SECONDS=1800
 VALIDATOR_HEARTBEAT_FRESH_SECONDS=900
 VALIDATOR_QUORUM_MIN=3
 VALIDATOR_QUORUM_TARGET=5
+# Economically inert text probes are still real GPU work. Core permits at most
+# one new text probe group per worker/model in this interval. Finalized
+# assignment/group operational rows are pruned after the scorecard API's
+# maximum 90-day window; signed attestation evidence remains append-only.
+VALIDATOR_TEXT_GROUP_MIN_INTERVAL_SECONDS=3600
+VALIDATOR_HISTORY_RETENTION_DAYS=90
+VALIDATOR_HISTORY_SWEEP_SECONDS=21600
 
 # Live custodial payout sender. Keep private keys blank in the template and
 # inject them through the production secret path.

--- a/docs/VERIFICATION_PROBES.md
+++ b/docs/VERIFICATION_PROBES.md
@@ -93,8 +93,11 @@ Mirrors the `GRID_CHARGING_ENABLED=0` and Validator-V0 patterns:
 - **Even when ON, evidence-only.** Attestations have **no** routing, reward, strike, slash,
   credit, or payout effect. A `fail` verdict changes nothing today — it is recorded and
   visible, nothing more. (There is nothing wired to consume verdicts, by design.)
-- Conservative cadence (`GRID_PROBE_INTERVAL`, default 300s), tiny prompts (`max_tokens`
-  ~24) so probe load on the GPU pool is negligible even in a 1-worker-per-model pool.
+- Legacy coordinator canaries retain their conservative `GRID_PROBE_INTERVAL`
+  cadence and tiny outputs. Shared-validator text probes are real GPU work,
+  including calibrated 32K context requests, so Core separately limits new
+  groups to one per worker/model per hour by default (with a five-minute hard
+  floor).
 
 ## Shared-quorum validator API (candidate preview)
 
@@ -128,6 +131,11 @@ strike, slash, credit, or payout effect. Text plus feature-gated image-fidelity
 and video-contract assignment paths exist in the candidate. Video remains
 default-off and proves only an objective output contract, not exact model
 fidelity.
+
+Each shared group owns one challenge copy; validator-specific assignment rows
+carry only their nonce and membership state and are hydrated at the API
+boundary. Core prunes finalized assignment/group machinery after 90 days by
+default while retaining signed attestations as the durable evidence record.
 
 Text challenge families are selected cryptographically rather than from worker
 ordering. Current candidate families are exact instruction, generated

--- a/docs/VERIFICATION_PROBES.md
+++ b/docs/VERIFICATION_PROBES.md
@@ -131,7 +131,7 @@ fidelity.
 
 Text challenge families are selected cryptographically rather than from worker
 ordering. Current candidate families are exact instruction, generated
-arithmetic, strict JSON, calibrated 4K/16K context retrieval, generated
+arithmetic, strict JSON, calibrated 4K/16K/32K context retrieval, generated
 multistep logic, and an exact single-function call plus a two-stage tool-call
 chain with randomized names and arguments. Tool-call evidence commits the
 witnessed text plus structured calls; Core and the node normalize each call
@@ -174,7 +174,7 @@ Deploy notes / learnings:
 
 ### Follow-ups (known, not yet done)
 1. **Grader hardening** — add hidden code execution, longer tool-call chains,
-   32K+ context tiers, and streaming-integrity checks. Keep judge models a
+   64K+ context tiers, and streaming-integrity checks. Keep judge models a
    supporting signal rather than an objective authority.
 2. **Media/video validator lanes** — deterministic image fidelity and
    non-deterministic video contract paths exist in the dark candidate and remain

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -332,13 +332,18 @@ credentials, hot queue state, and inference routing stay off-chain.
 
 ## Operations
 
-### 30. Consolidate important work on main branches - Implemented with archives
+### 30. Consolidate important work on main branches - Partial
 
-Current production repos have clean worktrees synchronized to their upstream
-main/master branches. Remaining side branches are dated archive, upstream-merge,
-or superseded WIP histories; none is a newer production release candidate.
-Preserve them as archaeology until deliberately retired rather than merging
-them wholesale.
+Production checkouts are clean, but reviewed release, validator, history-scan,
+contract-analysis, website, documentation, and SDK candidates still live on
+open branches. They are intentionally not merged wholesale: several default
+branches deploy or publish, validator changes require an independent approval,
+and Core rollout still requires the supervised backup/restore proof. Dated
+archive, upstream-merge, and superseded WIP branches remain archaeology rather
+than production candidates. The local `aipg-oss-release` toolkit is not a Git
+repository; its corrected scanner template and generated staging snapshots are
+therefore nondurable until that toolkit is either tracked or regenerated from a
+reviewed source.
 
 ### 31. Branch protection - Partial
 
@@ -365,14 +370,19 @@ credential was found and no credential value was copied into the audit record.
 The other findings were deterministic local-service fixture values, public
 cryptographic constants/test vectors in a retired paper-wallet bundle,
 documented placeholders, and operational metadata such as retired internal IPs,
-bucket names, and developer paths. Green history-gate PRs now replace broad
+bucket names, and developer paths. History-gate PRs now replace broad
 path, placeholder, address, and test-value allowlists with exact reviewed
 fingerprints or rule-scoped public constants across Core, text worker, media
-worker, validator, frontend, website, and contracts. Every gate scans complete
+worker, validator, frontend, website, contracts, documentation, and both current
+SDKs. Every gate scans complete
 reachable history with a checksum-verified scanner and uses a committed
 synthetic private-key negative control to prove that example labels cannot hide
-a future secret. These gates remain unmerged, so protected defaults are not yet
-uniformly hardened. Current protected-branch worktrees scan clean. Text, media,
+a future secret. The website, documentation, and SDK infrastructure scanners
+also self-test runtime-constructed blocked patterns and distinguish a clean
+no-match from scanner execution failure; this closed a false-green malformed
+regular-expression path discovered during local reproduction. These gates
+remain unmerged, so protected defaults are not yet uniformly hardened. Current
+protected-branch worktrees scan clean. Text, media,
 and validator release pipelines carry checksums, SBOM/provenance gates
 appropriate to their maturity.
 Text-worker `main` now requires the exact four-platform release-payload assembly
@@ -399,8 +409,13 @@ not retroactively protect older releases, qualify draft artifacts, or replace
 container-registry tag policy. Documentation PR 3 adds the organization-wide
 requirement for full-history scans, burned-secret rotation before cleanup,
 fingerprint-scoped baselines, signed release manifests/SBOMs, and exact
-deployment SHA/digest records. It remains unmerged, and implementation of that
-standard in every repository remains periodic work.
+deployment SHA/digest records. It also updates the docs build within Next 15 and
+Nextra 3 to versions with a zero-vulnerability `npm audit` result and a passing
+33-route production build. SDK PR 2 in each current SDK adds the same fail-closed
+history gate; the Python matrix passes 3.9-3.12, while the JavaScript candidate
+preserves and tests the declared Node 18 floor by pinning a compatible Vitest
+major. These changes remain unmerged, and implementation of the standard in
+every repository remains periodic work.
 
 ### 33. Public network status - Ready, endpoint rollout pending
 

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -217,7 +217,7 @@ benchmark, payout forecast, or fixed earnings promise.
 
 ## Better Validation
 
-### 19. Rich text validation - Partial
+### 19. Rich text validation - Ready, backend canaries pending
 
 Implemented randomized lanes cover exact instruction, arithmetic, strict JSON,
 calibrated 4K, 16K, and 32K context retrieval, multistep logic, one function
@@ -228,6 +228,9 @@ one bounded function AST and independently interpret only integer arithmetic.
 Context tiers require conservative worker-advertised headroom. Richer code and
 logic tiers, 64K+ long-context tiers, longer tool chains, and streaming integrity
 remain open; exact native-tokenizer equivalence is intentionally not claimed.
+Those are future depth, not substitutes for live proof of the implemented
+capability set. Production enablement still requires hard-targeted acceptance
+and negative canaries against representative text backends.
 
 ### 20. Private deterministic image validation - Ready dark
 

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -38,17 +38,24 @@ At this snapshot:
   release exists. A benchmark-only media-manager qualification prerelease is
   public, but it cannot enroll with the Grid or advertise capabilities.
 
-Read-only host verification on 2026-08-21 confirmed the immutable release and
-database revision above and found no scheduled database backup or off-host
-backup system. Core source now includes a locked, checksummed custom-format
-backup, hardened daily systemd timer, and guarded scratch restore/migration
-proof. The complete source path has passed twice against PostgreSQL 16, but the
-timer remains disabled and no production snapshot has been exercised. A
+Host verification on 2026-08-21 confirmed the immutable release and database
+revision above and found no scheduled database backup or off-host backup
+system. A supervised rehearsal at exact candidate `c73864ee` then created a
+66,866,179-byte checksummed production snapshot, restored it into the guarded
+scratch database, upgraded `0019` through `0024`, passed `alembic current`,
+`heads`, and `check`, and removed the scratch database. The rehearsal first
+exposed two real portability defects: the backup included unrelated `cron`
+extension state, and a schema-scoped archive collided with the scratch
+database's default `public` schema. Candidate commits `290c0375` and `c73864ee`
+scope archives to the Grid-owned schema, explicitly reset only the generated
+scratch schema, and make the PostgreSQL 16 restore proof a pull-request gate.
+The backup timer remains disabled and no off-host backup system exists. A
 separate PostgreSQL rehearsal upgraded `0019` to
 `0024` with 100,000 synthetic legacy assignments and 110,000 synthetic legacy
 attestations in place, preserved every row, completed locally in 0.66 seconds,
-and passed `alembic check` with no schema drift. This proves the migration data
-shape and constraints, not production lock duration or backup restoration.
+and passed `alembic check` with no schema drift. That synthetic rehearsal proves
+the migration data shape and constraints; production restoration is evidenced
+separately above, while production migration lock duration remains unmeasured.
 
 ## Approval-Ready Merge Sequence
 
@@ -57,16 +64,16 @@ evidence snapshot. Recheck the exact head and required statuses immediately
 before each merge; a green ancestor or paired branch does not prove a changed
 head.
 
-1. Land history/security foundations before feature branches: Core PR 22
-   (`e798b440`), text-worker PR 15 (`db8f9424`), media-worker PR 14
-   (`ac05d780`), Console PR 16 (`4edbd952`), contracts PR 4
-   (`a814693a`), website PR 5 (`e3432ea1`), documentation PR 3
-   (`bf1bff22`), Python SDK PR 2 (`890abbe0`), JavaScript SDK PR 2
-   (`2fa540fc`), and validator PR 3 (`17ce7357`). Validator PR 3 still
+1. Six non-deploying history/security foundations are merged and green on
+   protected `main`: Core PR 22 (`471e849a`), text-worker PR 15 (`c03f7d19`),
+   media-worker PR 14 (`1423e440`), contracts PR 4 (`69c48b86`), Python SDK PR
+   2 (`d6073054`), and JavaScript SDK PR 2 (`6e07bfd6`). Remaining foundations
+   are Console PR 16 (`4edbd952`), website PR 5 (`e3432ea1`), documentation PR
+   3 (`bf1bff22`), and validator PR 3 (`17ce7357`). Validator PR 3 still
    requires the configured independent approval. Treat website, Console, and
    documentation default-branch merges as deployment-capable because their
    hosting integrations are outside the source diff.
-2. Land contracts PR 3 (`c8015c2b`) after contracts PR 4. This enables
+2. Land contracts PR 3 (`03dc08b5`) after contracts PR 4. This enables
    deployable-contract Slither policy and tested source changes only; it does
    not authorize a Diamond cut or any Base transaction.
 3. Land validator release PR 2 (`4b226ad6`) after validator PR 3, then
@@ -76,10 +83,11 @@ head.
 4. Land website rollout PR 4 (`01dc7d24`) only after website PR 5 and explicit
    production approval. Its release-policy and browser tests are green, but a
    main merge deploys the public worker/validator onboarding surface.
-5. Land Core validator PR 21 only after Core PR 22, a supervised
-   production snapshot plus scratch restore, a signed-in account/validator
-   acceptance pass, and explicit deployment approval. Merge is not proof that
-   production moved from `20d57669` or Alembic `0019`.
+5. Core validator PR 21 at `c73864ee` is rebased after Core PR 22 and its
+   supervised production snapshot plus scratch restore has passed. Land it
+   only after a signed-in account/validator acceptance pass and explicit
+   deployment approval. Merge is not proof that production moved from
+   `20d57669` or Alembic `0019`.
 
 After each paired merge, refresh the dependent PR against the new default
 branch and rerun every required status. Contract code, release artifacts,
@@ -219,7 +227,7 @@ tag-commit, and platform-signing checks; bounds downloaded manifest and checksum
 files before buffering; caches immutable release evidence for 24 hours; exposes
 the benchmark-only media qualification tool as non-enrolling; and keeps final
 downloads closed until verified releases exist. Its 29 release-gate tests and
-six desktop/mobile browser tests pass, including the real immutable
+eight desktop/mobile browser tests pass, including the real immutable
 qualification release and deliberately incomplete legacy text release. That PR
 remains unmerged because website `main` deploys production. Do not call this
 item complete until the reviewed rollout is explicitly approved, deployed, and
@@ -476,7 +484,7 @@ failover, and later multi-authority ordering. No federation code is live. Begin
 only after validator quorum, event replay, and economic-state invariants are
 proven.
 
-### 35. Verified database backup and restore - Ready, production proof pending
+### 35. Verified database backup and restore - Production proof complete
 
 Core source creates locked PostgreSQL custom-format dumps, verifies archive
 structure, binds one SHA-256 manifest to the exact dump, refuses overwrite,
@@ -484,17 +492,17 @@ uses root-only storage, and applies bounded local retention. The restore tool
 accepts only local PostgreSQL, creates and drops only a generated
 `aipg_restore_proof_*` database, restores as the application owner, migrates
 with the exact immutable candidate, and requires `alembic current`, `heads`,
-and `check` agreement. CI rehearses `0019` backup through `0024` restore on
-PostgreSQL 16. The systemd units pass clean-environment verification. The
-remaining gate is a supervised production backup plus scratch restore before
-first enablement. Local retention is not off-host disaster recovery.
+and `check` agreement. Pull-request CI rehearses `0019` backup through `0024`
+restore on PostgreSQL 16 and proves a decoy non-Grid schema is excluded. The
+supervised production proof passed at exact candidate `c73864ee`; the generated
+scratch database was removed. The systemd units pass clean-environment
+verification. Timer enablement remains a separate operational decision, and
+local retention is not off-host disaster recovery.
 
 ## Next Controlled Sequence
 
-1. Run the candidate backup tool against production and prove that exact
-   snapshot in its guarded scratch database. Source-level PostgreSQL 16 backup,
-   restore, `0019` to `0024` migration, schema-parity, and cleanup rehearsals
-   are complete, but a production snapshot has not been exercised.
+1. Complete signed-in account and validator acceptance against the exact Core
+   candidate without enabling economic effects.
 2. Obtain explicit deployment authorization for the exact reviewed Core commit.
 3. Deploy it immutably, migrate through `0024`, and verify build identity,
    charging flags, payout timer state, workers, model inventory, retired API

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -64,30 +64,29 @@ evidence snapshot. Recheck the exact head and required statuses immediately
 before each merge; a green ancestor or paired branch does not prove a changed
 head.
 
-1. Six non-deploying history/security foundations are merged and green on
-   protected `main`: Core PR 22 (`471e849a`), text-worker PR 15 (`c03f7d19`),
-   media-worker PR 14 (`1423e440`), contracts PR 4 (`69c48b86`), Python SDK PR
-   2 (`d6073054`), and JavaScript SDK PR 2 (`6e07bfd6`). Remaining foundations
-   are Console PR 16 (`4edbd952`), website PR 5 (`e3432ea1`), documentation PR
-   3 (`bf1bff22`), and validator PR 3 (`17ce7357`). Validator PR 3 still
-   requires the configured independent approval. Treat website, Console, and
-   documentation default-branch merges as deployment-capable because their
-   hosting integrations are outside the source diff.
-2. Land contracts PR 3 (`03dc08b5`) after contracts PR 4. This enables
+1. Nine history/security foundations are merged on protected default branches:
+   Core PR 22 (`471e849a`), text-worker PR 15 (`c03f7d19`), media-worker PR 14
+   (`1423e440`), contracts PR 4 (`69c48b86`), Python SDK PR 2 (`d6073054`),
+   JavaScript SDK PR 2 (`6e07bfd6`), Console PR 16 (`ad39a7db`), website PR 5
+   (`300c69e1`), and documentation PR 3 (`6d241e7a`). Their post-merge checks
+   and hosting builds must remain green. Validator PR 3 (`17ce7357`) is the
+   remaining foundation and still requires the configured independent approval.
+2. Contracts PR 3 is merged at `8899348a` after contracts PR 4. This enables
    deployable-contract Slither policy and tested source changes only; it does
    not authorize a Diamond cut or any Base transaction.
 3. Land validator release PR 2 (`4b226ad6`) after validator PR 3, then
    validator capability PR 4 (`81b66390`). Both require independent review.
    Do not create a tag or publish binaries until Core is rolled out, a live
    authenticated canary passes, and macOS/Windows signing evidence is present.
-4. Land website rollout PR 4 (`01dc7d24`) only after website PR 5 and explicit
+4. Land website rollout PR 4 (`5a08d50`) only after website PR 5 and explicit
    production approval. Its release-policy and browser tests are green, but a
    main merge deploys the public worker/validator onboarding surface.
-5. Core validator PR 21 at `c73864ee` is rebased after Core PR 22 and its
-   supervised production snapshot plus scratch restore has passed. Land it
-   only after a signed-in account/validator acceptance pass and explicit
-   deployment approval. Merge is not proof that production moved from
-   `20d57669` or Alembic `0019`.
+5. Core validator PR 21 has a runtime-proven candidate at `c73864ee` and a
+   readiness-document-only descendant at `3c3eeed9`, both after Core PR 22. Its
+   supervised production snapshot plus scratch restore has passed. Land the
+   exact final green head only after a signed-in account/validator acceptance
+   pass and explicit deployment approval. Merge is not proof that production
+   moved from `20d57669` or Alembic `0019`.
 
 After each paired merge, refresh the dependent PR against the new default
 branch and rerun every required status. Contract code, release artifacts,

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -110,8 +110,11 @@ testing**, not decentralized validation.
 
 ### 8. Shared probe groups - Ready
 
-Core source persists one immutable challenge group, distinct assignments,
-independent attestations, and pending/accepted/disputed/finalized states.
+Core source persists one immutable challenge copy per group, distinct
+validator assignments, independent attestations, and
+pending/accepted/disputed/finalized states. New text groups are rate-bounded per
+worker/model, and finalized operational rows are retention-bounded while signed
+evidence remains durable.
 Production still runs the older Core.
 
 ### 9. Distinct registered 3-of-5 quorum - Ready

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -76,7 +76,7 @@ head.
 4. Land website rollout PR 4 (`01dc7d24`) only after website PR 5 and explicit
    production approval. Its release-policy and browser tests are green, but a
    main merge deploys the public worker/validator onboarding surface.
-5. Land Core validator PR 21 (`a8c48ecd`) only after Core PR 22, a supervised
+5. Land Core validator PR 21 only after Core PR 22, a supervised
    production snapshot plus scratch restore, a signed-in account/validator
    acceptance pass, and explicit deployment approval. Merge is not proof that
    production moved from `20d57669` or Alembic `0019`.

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -213,11 +213,12 @@ benchmark, payout forecast, or fixed earnings promise.
 ### 19. Rich text validation - Partial
 
 Implemented randomized lanes cover exact instruction, arithmetic, strict JSON,
-calibrated 4K and 16K context retrieval, multistep logic, one function call, a
+calibrated 4K, 16K, and 32K context retrieval, multistep logic, one function
+call, a
 two-stage tool chain, stop-sequence compliance, and gross output-budget
 compliance using an independent model-agnostic token counter with
 cross-tokenizer tolerance. Context tiers require conservative worker-advertised
-headroom. Hidden code execution, 32K+ long-context tiers, longer tool chains,
+headroom. Hidden code execution, 64K+ long-context tiers, longer tool chains,
 and streaming integrity remain open; exact native-tokenizer equivalence is
 intentionally not claimed.
 

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -50,6 +50,42 @@ attestations in place, preserved every row, completed locally in 0.66 seconds,
 and passed `alembic check` with no schema drift. This proves the migration data
 shape and constraints, not production lock duration or backup restoration.
 
+## Approval-Ready Merge Sequence
+
+All pull requests listed here were mergeable with green hosted checks at the
+evidence snapshot. Recheck the exact head and required statuses immediately
+before each merge; a green ancestor or paired branch does not prove a changed
+head.
+
+1. Land history/security foundations before feature branches: Core PR 22
+   (`e798b440`), text-worker PR 15 (`db8f9424`), media-worker PR 14
+   (`ac05d780`), Console PR 16 (`4edbd952`), contracts PR 4
+   (`a814693a`), website PR 5 (`e3432ea1`), documentation PR 3
+   (`bf1bff22`), Python SDK PR 2 (`890abbe0`), JavaScript SDK PR 2
+   (`2fa540fc`), and validator PR 3 (`17ce7357`). Validator PR 3 still
+   requires the configured independent approval. Treat website, Console, and
+   documentation default-branch merges as deployment-capable because their
+   hosting integrations are outside the source diff.
+2. Land contracts PR 3 (`c8015c2b`) after contracts PR 4. This enables
+   deployable-contract Slither policy and tested source changes only; it does
+   not authorize a Diamond cut or any Base transaction.
+3. Land validator release PR 2 (`4b226ad6`) after validator PR 3, then
+   validator capability PR 4 (`81b66390`). Both require independent review.
+   Do not create a tag or publish binaries until Core is rolled out, a live
+   authenticated canary passes, and macOS/Windows signing evidence is present.
+4. Land website rollout PR 4 (`01dc7d24`) only after website PR 5 and explicit
+   production approval. Its release-policy and browser tests are green, but a
+   main merge deploys the public worker/validator onboarding surface.
+5. Land Core validator PR 21 (`a8c48ecd`) only after Core PR 22, a supervised
+   production snapshot plus scratch restore, a signed-in account/validator
+   acceptance pass, and explicit deployment approval. Merge is not proof that
+   production moved from `20d57669` or Alembic `0019`.
+
+After each paired merge, refresh the dependent PR against the new default
+branch and rerun every required status. Contract code, release artifacts,
+production migrations, charging changes, and Base transactions remain separate
+approval events.
+
 ## Immediate Validator Preview
 
 ### 1. Dedicated validator API scopes - Ready

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -379,7 +379,14 @@ archive, upstream-merge, and superseded WIP branches remain archaeology rather
 than production candidates. The local `aipg-oss-release` toolkit is not a Git
 repository; its corrected scanner template and generated staging snapshots are
 therefore nondurable until that toolkit is either tracked or regenerated from a
-reviewed source.
+reviewed source. Local deprecation/DOX commits also remain in
+`aipg-horde-api`, `grid-rewards-sentry`, and the retired `grid-sdk`, whose
+AIPowerGrid remotes now return repository-not-found, plus
+`grid-discord-image-bot`, whose remote is archived read-only. The image bot
+also retains pre-existing TypeScript failures and high-severity dependency
+advisories. None is a current network component or merge candidate; do not
+restore those remotes or revive the code merely to eliminate a local ahead
+count.
 
 ### 31. Branch protection - Partial
 

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -221,13 +221,13 @@ benchmark, payout forecast, or fixed earnings promise.
 
 Implemented randomized lanes cover exact instruction, arithmetic, strict JSON,
 calibrated 4K, 16K, and 32K context retrieval, multistep logic, one function
-call, a
-two-stage tool chain, stop-sequence compliance, and gross output-budget
-compliance using an independent model-agnostic token counter with
-cross-tokenizer tolerance. Context tiers require conservative worker-advertised
-headroom. Hidden code execution, 64K+ long-context tiers, longer tool chains,
-and streaming integrity remain open; exact native-tokenizer equivalence is
-intentionally not claimed.
+call, a two-stage tool chain, stop-sequence compliance, gross output-budget
+compliance, and Python function synthesis checked against assignment-only hidden
+inputs. The code lane never executes worker code: Core and each validator parse
+one bounded function AST and independently interpret only integer arithmetic.
+Context tiers require conservative worker-advertised headroom. Richer code and
+logic tiers, 64K+ long-context tiers, longer tool chains, and streaming integrity
+remain open; exact native-tokenizer equivalence is intentionally not claimed.
 
 ### 20. Private deterministic image validation - Ready dark
 

--- a/docs/architecture/NETWORK_READINESS.md
+++ b/docs/architecture/NETWORK_READINESS.md
@@ -178,12 +178,16 @@ The production page presents text and media independently, so an unfinished
 media release does not hide text onboarding. Its current release lookup is not
 yet the authoritative gate: it accepts published asset names without validating
 the complete manifest/checksum contract or platform-signing identities. The
-green website rollout PR adds exact asset-set, digest, size, SBOM, manifest, and
-platform-signing checks; exposes the benchmark-only media qualification tool as
-non-enrolling; and keeps final downloads closed until verified releases exist.
-That PR remains unmerged because website `main` deploys production. Do not call
-this item complete until the reviewed rollout is explicitly approved, deployed,
-and checked against both valid and deliberately incomplete release fixtures.
+green website rollout PR adds exact asset-set, digest, size, SBOM, manifest,
+tag-commit, and platform-signing checks; bounds downloaded manifest and checksum
+files before buffering; caches immutable release evidence for 24 hours; exposes
+the benchmark-only media qualification tool as non-enrolling; and keeps final
+downloads closed until verified releases exist. Its 29 release-gate tests and
+six desktop/mobile browser tests pass, including the real immutable
+qualification release and deliberately incomplete legacy text release. That PR
+remains unmerged because website `main` deploys production. Do not call this
+item complete until the reviewed rollout is explicitly approved, deployed, and
+checked on the production page.
 
 ### 16. Three independent workers per flagship model - External
 
@@ -338,9 +342,10 @@ them wholesale.
 Core, contracts, text worker, media worker, and validator require their current
 CI/security status names. Validator `master` additionally enforces one approving
 review, stale-review dismissal, admin compliance, linear history, resolved
-conversations, and no force-push/deletion. Administrative bypass and zero
-required reviews remain a sole-maintainer tradeoff on the other protected repos,
-so their rules do not prevent an admin from pushing before checks finish. Stale
+conversations, and no force-push/deletion. The other protected repos also enforce
+rules for administrators and do not permit force-push/deletion, but zero required
+reviews remains a sole-maintainer tradeoff: a maintainer can merge or directly
+commit once strict required checks pass without independent approval. Stale
 status names must be reconciled whenever a workflow matrix changes. Media-worker
 `main` now requires a stable final manager-release gate in addition to its test,
 dependency, and secret checks; the gate itself depends on both platform builds.
@@ -357,11 +362,16 @@ credential was found and no credential value was copied into the audit record.
 The other findings were deterministic local-service fixture values, public
 cryptographic constants/test vectors in a retired paper-wallet bundle,
 documented placeholders, and operational metadata such as retired internal IPs,
-bucket names, and developer paths. Full-history scanning is still not a clean
-enforced gate: those reachable findings require either coordinated history
-repair or exact-fingerprint baselines with rationale and review dates. Current
-protected-branch worktrees scan clean. Text, media, and validator release
-pipelines carry checksums, SBOM/provenance gates appropriate to their maturity.
+bucket names, and developer paths. Green history-gate PRs now replace broad
+path, placeholder, address, and test-value allowlists with exact reviewed
+fingerprints or rule-scoped public constants across Core, text worker, media
+worker, validator, frontend, website, and contracts. Every gate scans complete
+reachable history with a checksum-verified scanner and uses a committed
+synthetic private-key negative control to prove that example labels cannot hide
+a future secret. These gates remain unmerged, so protected defaults are not yet
+uniformly hardened. Current protected-branch worktrees scan clean. Text, media,
+and validator release pipelines carry checksums, SBOM/provenance gates
+appropriate to their maturity.
 Text-worker `main` now requires the exact four-platform release-payload assembly
 check on every change. Media-worker `main` records explicit Authenticode state,
 runs Linux and Windows manager packaging on every change, and requires their

--- a/docs/architecture/VALIDATOR_V0.md
+++ b/docs/architecture/VALIDATOR_V0.md
@@ -71,7 +71,7 @@ committed output and transport hashes, never Core's private verdict. Each node
 scores that output locally before signing.
 
 Candidate text families are randomized exact instruction, generated
-arithmetic, strict JSON object compliance, calibrated 4K/16K context retrieval,
+arithmetic, strict JSON object compliance, calibrated 4K/16K/32K context retrieval,
 generated multistep integer logic, one exact randomized function call, one
 exact two-stage tool-call chain, and randomized stop-sequence compliance. The
 validator registration must advertise the matching scorer capability before it

--- a/docs/architecture/VALIDATOR_V0.md
+++ b/docs/architecture/VALIDATOR_V0.md
@@ -85,6 +85,11 @@ The targeted probe is isolated from customer economics: it does not reserve or
 settle demand credits, award den, create a payout ledger completion, or apply a
 worker strike.
 
+It still consumes worker capacity. Core therefore creates at most one new text
+probe group per worker/model per configured interval (one hour by default,
+never less than five minutes). A group stores one challenge copy and assignments
+resolve it at issue/probe time instead of duplicating large 32K payloads.
+
 Core hard-targets the job internally but sends the worker an ordinary opaque
 UUID and a payload with all validator assignment/group/nonce markers removed.
 Those fields are restored only into the Core-to-validator evidence response
@@ -112,6 +117,10 @@ canonical account, and DB-enforced one-assignment/one-attestation membership per
 validator and group. Apply all migrations before deploying shared-quorum Core
 code. Existing legacy evidence may remain unbound and must never be upgraded to
 authoritative by inference.
+
+Finalized assignment and group rows are operational state and are pruned after
+90 days by default. Signed attestation rows remain the durable evidence record;
+the pruning job does not delete them.
 
 ## Next Authority Gate
 

--- a/grid_api/AGENTS.md
+++ b/grid_api/AGENTS.md
@@ -18,8 +18,8 @@ chain sync, and settlement scaffolding. Entry point: `main.py`.
   and worker structures.
 - `abis/` / `_abi.py` - local contract ABI loaders used by background sync.
 - `main.py` - lifecycle: DB/Redis init, stale-job reclaimer, reservation and
-  billing invariant monitors, operator alerts, recipe sync, router registration,
-  and root health metadata.
+  billing invariant monitors, validator operational-history pruning, operator
+  alerts, recipe sync, router registration, and root health metadata.
 
 ## Local Contracts
 

--- a/grid_api/config.py
+++ b/grid_api/config.py
@@ -64,6 +64,12 @@ class GridSettings(BaseSettings):
     validator_media_minimum_quality_pass_rate: float = 0.95
     validator_media_max_output_bytes: int = 25 * 1024 * 1024
     validator_media_probe_timeout_seconds: int = 600
+    # Bound economically inert preview work and its operational DB footprint.
+    # A completed quorum must not immediately manufacture another free probe
+    # group for the same worker/model.
+    validator_text_group_min_interval_seconds: int = 3600
+    validator_history_retention_days: int = 90
+    validator_history_sweep_seconds: int = 21600
 
     # Best-effort operator alerts. The webhook is a production secret and must
     # never be committed, logged, or returned by an API.

--- a/grid_api/main.py
+++ b/grid_api/main.py
@@ -104,6 +104,34 @@ async def _reservation_sweeper():
         await asyncio.sleep(interval)
 
 
+async def _validator_history_sweeper():
+    """Bound finalized validator assignment/group storage.
+
+    Signed attestations remain append-only; only the operational rows that held
+    leases and private challenges are removed after the public health window.
+    """
+    from .config import get_settings
+    from .safe_logging import error_type
+    from .services.validators import prune_validator_operational_history
+
+    interval = max(3600, get_settings().validator_history_sweep_seconds)
+    while True:
+        try:
+            deleted = await prune_validator_operational_history()
+            if deleted["assignments"] or deleted["probe_groups"]:
+                logger.info(
+                    "Pruned finalized validator rows assignments=%d probe_groups=%d",
+                    deleted["assignments"],
+                    deleted["probe_groups"],
+                )
+        except Exception as exc:
+            logger.error(
+                "Validator history sweeper error_type=%s",
+                error_type(exc),
+            )
+        await asyncio.sleep(interval)
+
+
 async def _recipe_sync_loop():
     """Background task: refresh approved recipes from on-chain RecipeVault.
     No-ops until RECIPEVAULT_ADDRESS/BASE_RPC_URL are set; curated local recipes
@@ -201,6 +229,7 @@ async def lifespan(app: FastAPI):
     _styles.load_local_styles(os.path.join(_base, "styles"))
     recipe_sync = asyncio.create_task(_recipe_sync_loop())
     sweeper = asyncio.create_task(_reservation_sweeper())
+    validator_history_sweeper = asyncio.create_task(_validator_history_sweeper())
     billing_monitor = asyncio.create_task(_billing_monitor())
     # Verification probes ("validator zero") — dormant unless GRID_PROBE_ENABLED;
     # even ON it only records evidence (no reward/slash). See VERIFICATION_PROBES.md.
@@ -225,6 +254,7 @@ async def lifespan(app: FastAPI):
     reclaimer.cancel()
     recipe_sync.cancel()
     sweeper.cancel()
+    validator_history_sweeper.cancel()
     billing_monitor.cancel()
     prober.cancel()
     await close_p2p()  # Shutdown P2P

--- a/grid_api/routers/tests/test_validator_assignments.py
+++ b/grid_api/routers/tests/test_validator_assignments.py
@@ -831,6 +831,22 @@ async def test_assignment_groups_require_matching_validator_scorer_capability(db
     assert rich_assignment["capability"] == "text.structured.v1"
     assert rich_assignment["canary_kind"] == "json.object"
 
+    # The per-worker cadence is deliberate. Age the first capability group so
+    # this test can exercise the separate legacy-capability group.
+    async with await database.new_session() as session:
+        await session.execute(
+            sa.update(probe_groups_t)
+            .where(probe_groups_t.c.id == rich_assignment["probe_group_id"])
+            .values(
+                created=validators_svc._now()
+                - timedelta(
+                    seconds=validators_svc.get_settings().validator_text_group_min_interval_seconds
+                    + 1
+                )
+            )
+        )
+        await session.commit()
+
     legacy_key = "0x" + f"{31:064x}"
     legacy_wallet = Account.from_key(legacy_key).address.lower()
     legacy_account = uuid.uuid4()
@@ -930,6 +946,142 @@ async def test_32k_context_assignment_requires_target_worker_headroom(db):
     assert issued["count"] == 1
     assert issued["assignments"][0]["canary_kind"] == "context.retrieve.32k"
     assert issued["assignments"][0]["scoring_policy_id"] == "text.generated.v6"
+
+    assignment = issued["assignments"][0]
+    async with await database.new_session() as session:
+        stored_assignment = (
+            await session.execute(
+                sa.select(assignments_t.c.challenge).where(
+                    assignments_t.c.id == assignment["assignment_id"]
+                )
+            )
+        ).scalar_one()
+        stored_group = (
+            await session.execute(
+                sa.select(probe_groups_t.c.challenge).where(
+                    probe_groups_t.c.id == assignment["probe_group_id"]
+                )
+            )
+        ).scalar_one()
+    assert stored_assignment == {}
+    assert stored_group["prompt"] == assignment["challenge"]["prompt"]
+
+    reloaded = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=wallet,
+        active_workers=[worker],
+        limit=1,
+    )
+    assert reloaded["assignments"][0]["challenge"] == assignment["challenge"]
+
+
+@pytest.mark.asyncio
+async def test_text_group_cadence_blocks_immediate_replacement(db):
+    private_key = "0x" + f"{34:064x}"
+    wallet = Account.from_key(private_key).address.lower()
+    account_id = uuid.uuid4()
+    validator_id = await _register(
+        account_id,
+        private_key,
+        capabilities=["text.context.32k.v1"],
+    )
+    worker = {
+        "worker_id": str(uuid.uuid4()),
+        "name": "rig-context-cadence",
+        "models": ["qwen3-27b"],
+        "job_types": ["text"],
+        "max_context_length": 65_536,
+    }
+    first = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=wallet,
+        active_workers=[worker],
+        limit=1,
+    )
+    assignment = first["assignments"][0]
+    now = validators_svc._now()
+    async with await database.new_session() as session:
+        await session.execute(
+            sa.update(assignments_t)
+            .where(assignments_t.c.id == assignment["assignment_id"])
+            .values(status="finalized", quorum_status="finalized", finalized=now)
+        )
+        await session.execute(
+            sa.update(probe_groups_t)
+            .where(probe_groups_t.c.id == assignment["probe_group_id"])
+            .values(status="finalized", quorum_status="finalized", finalized=now)
+        )
+        await session.commit()
+
+    blocked = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=wallet,
+        active_workers=[worker],
+        limit=1,
+    )
+    assert blocked["count"] == 0
+
+    async with await database.new_session() as session:
+        await session.execute(
+            sa.update(probe_groups_t)
+            .where(probe_groups_t.c.id == assignment["probe_group_id"])
+            .values(
+                created=now
+                - timedelta(
+                    seconds=validators_svc.get_settings().validator_text_group_min_interval_seconds
+                    + 1
+                )
+            )
+        )
+        await session.commit()
+    replacement = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=wallet,
+        active_workers=[worker],
+        limit=1,
+    )
+    assert replacement["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_prune_removes_finalized_machinery_but_keeps_signed_evidence(db):
+    account_id = uuid.uuid4()
+    validator_id, assignment, payload = await _assignment(account_id)
+    await validators_svc.record_attestation(
+        account_id=account_id,
+        validator_id=validator_id,
+        payload=payload,
+        signature=_sign(payload),
+    )
+    old = validators_svc._now() - timedelta(days=2)
+    async with await database.new_session() as session:
+        await session.execute(
+            sa.update(assignments_t)
+            .where(assignments_t.c.id == assignment["assignment_id"])
+            .values(status="finalized", quorum_status="finalized", finalized=old)
+        )
+        await session.execute(
+            sa.update(probe_groups_t)
+            .where(probe_groups_t.c.id == assignment["probe_group_id"])
+            .values(status="finalized", quorum_status="finalized", finalized=old)
+        )
+        await session.commit()
+
+    deleted = await validators_svc.prune_validator_operational_history(
+        older_than_days=1
+    )
+    assert deleted == {"assignments": 1, "probe_groups": 1}
+    async with await database.new_session() as session:
+        assert await session.scalar(sa.select(sa.func.count()).select_from(assignments_t)) == 0
+        assert await session.scalar(sa.select(sa.func.count()).select_from(probe_groups_t)) == 0
+        evidence = (
+            await session.execute(sa.select(attestations_t.c.payload))
+        ).scalar_one()
+    assert evidence["evidence_hash"] == payload["evidence_hash"]
 
 
 @pytest.mark.asyncio

--- a/grid_api/routers/tests/test_validator_assignments.py
+++ b/grid_api/routers/tests/test_validator_assignments.py
@@ -893,6 +893,46 @@ async def test_16k_context_assignment_requires_target_worker_headroom(db):
 
 
 @pytest.mark.asyncio
+async def test_32k_context_assignment_requires_target_worker_headroom(db):
+    private_key = "0x" + f"{33:064x}"
+    wallet = Account.from_key(private_key).address.lower()
+    account_id = uuid.uuid4()
+    validator_id = await _register(
+        account_id,
+        private_key,
+        capabilities=["text.context.32k.v1"],
+    )
+    worker = {
+        "worker_id": str(uuid.uuid4()),
+        "name": "rig-context-32k",
+        "models": ["qwen3-27b"],
+        "job_types": ["text"],
+        "max_context_length": 32_768,
+    }
+
+    blocked = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=wallet,
+        active_workers=[worker],
+        limit=1,
+    )
+    assert blocked["count"] == 0
+
+    worker["max_context_length"] = 65_536
+    issued = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=wallet,
+        active_workers=[worker],
+        limit=1,
+    )
+    assert issued["count"] == 1
+    assert issued["assignments"][0]["canary_kind"] == "context.retrieve.32k"
+    assert issued["assignments"][0]["scoring_policy_id"] == "text.generated.v6"
+
+
+@pytest.mark.asyncio
 async def test_completed_probe_can_deliver_during_attestation_grace(db):
     account_id = uuid.uuid4()
     validator_id, assignment, payload = await _assignment(account_id, verdict="healthy")

--- a/grid_api/routers/tests/test_validator_assignments.py
+++ b/grid_api/routers/tests/test_validator_assignments.py
@@ -4,6 +4,7 @@
 import asyncio
 import hashlib
 import json
+import re
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -905,7 +906,7 @@ async def test_16k_context_assignment_requires_target_worker_headroom(db):
     )
     assert issued["count"] == 1
     assert issued["assignments"][0]["canary_kind"] == "context.retrieve.16k"
-    assert issued["assignments"][0]["scoring_policy_id"] == "text.generated.v6"
+    assert issued["assignments"][0]["scoring_policy_id"] == "text.generated.v7"
 
 
 @pytest.mark.asyncio
@@ -945,7 +946,7 @@ async def test_32k_context_assignment_requires_target_worker_headroom(db):
     )
     assert issued["count"] == 1
     assert issued["assignments"][0]["canary_kind"] == "context.retrieve.32k"
-    assert issued["assignments"][0]["scoring_policy_id"] == "text.generated.v6"
+    assert issued["assignments"][0]["scoring_policy_id"] == "text.generated.v7"
 
     assignment = issued["assignments"][0]
     async with await database.new_session() as session:
@@ -1485,6 +1486,69 @@ async def test_stop_sequence_is_exposed_and_forwarded_to_the_targeted_request(db
     assert result["status"] == "error"
     assert assignment["challenge"]["stop"]
     assert submitted["request"]["stop"] == assignment["challenge"]["stop"]
+
+
+@pytest.mark.asyncio
+async def test_code_probe_forwards_only_prompt_and_scores_hidden_tests(db, monkeypatch):
+    from grid_api.services import job_queue, token_stream
+
+    account_id = uuid.uuid4()
+    validator_id = await _register(account_id, capabilities=["text.code.v1"])
+    issued = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=TEST_WALLET,
+        active_workers=[{
+            "worker_id": str(uuid.uuid4()), "name": "rig-code",
+            "models": ["qwen3-27b"], "job_types": ["text"],
+        }],
+        limit=1,
+    )
+    assignment = issued["assignments"][0]
+    challenge = assignment["challenge"]
+    match = re.search(
+        r"multiply x by (\d+), add (-?\d+), take the result modulo (\d+).*subtract (\d+)",
+        challenge["prompt"],
+    )
+    assert match is not None
+    multiplier, offset, modulus, adjustment = map(int, match.groups())
+    output_text = (
+        f"def {challenge['function_name']}(x):\n"
+        f"    return ((x * {multiplier} + {offset}) % {modulus}) - {adjustment}"
+    )
+    submitted = {}
+
+    async def capture_submit(job_id, payload, models, **kwargs):
+        submitted.update(job_id=job_id, payload=payload, models=models, kwargs=kwargs)
+
+    async def completed_events(*_args, **_kwargs):
+        yield {
+            "text": token_stream.DONE_SENTINEL,
+            "full_text": output_text,
+            "finish_reason": "stop",
+            "usage": {"completion_tokens": 32},
+            "grid": {"worker": "rig-code"},
+        }
+
+    monkeypatch.setattr(job_queue, "submit_job", capture_submit)
+    monkeypatch.setattr(token_stream, "subscribe_tokens", completed_events)
+    result = await validators_svc.probe_assignment(
+        account_id=account_id,
+        validator_id=validator_id,
+        assignment_id=assignment["assignment_id"],
+    )
+
+    assert result["status"] == "completed"
+    assert result["canary_kind"] == "code.function"
+    assert submitted["payload"]["request"]["messages"][-1]["content"] == challenge["prompt"]
+    assert "test_inputs" not in json.dumps(submitted["payload"])
+    assert submitted["kwargs"]["hard_target_worker"] == "rig-code"
+    async with await database.new_session() as session:
+        row = (await session.execute(
+            sa.select(assignments_t).where(assignments_t.c.id == assignment["assignment_id"])
+        )).mappings().one()
+    assert row["probe_status"] == "completed"
+    assert row["probe_verdict"] == "healthy"
 
 
 @pytest.mark.asyncio

--- a/grid_api/routers/tests/test_validator_concurrency.py
+++ b/grid_api/routers/tests/test_validator_concurrency.py
@@ -25,6 +25,7 @@ from grid_api.services import validators as validators_svc
 from grid_api.v2.schema import accounts as accounts_t
 from grid_api.v2.schema import metadata as v2_metadata
 from grid_api.v2.schema import validator_assignments as assignments_t
+from grid_api.v2.schema import validator_attestations as attestations_t
 from grid_api.v2.schema import validator_probe_groups as probe_groups_t
 from grid_api.v2.schema import validator_reference_workers as references_t
 from grid_api.v2.schema import validators as validators_t
@@ -448,6 +449,80 @@ async def test_concurrent_validators_join_one_shared_probe_group(pg):
     async with await database.new_session() as session:
         assert await session.scalar(sa.select(sa.func.count()).select_from(probe_groups_t)) == 1
         assert await session.scalar(sa.select(sa.func.count()).select_from(assignments_t)) == 5
+
+
+@pytest.mark.asyncio
+async def test_postgres_prune_preserves_evidence_and_clears_retired_links(pg):
+    account_id, validator_id, wallet, _private_key = (await _seed_validators(1))[0]
+    issued = await validators_svc.issue_assignments(
+        account_id=account_id,
+        validator_id=validator_id,
+        validator_wallet=wallet,
+        active_workers=_workers(),
+        limit=1,
+    )
+    assignment = issued["assignments"][0]
+    evidence_hash = "a" * 64
+    evidence_payload = {
+        "assignment_id": assignment["assignment_id"],
+        "probe_group_id": assignment["probe_group_id"],
+        "evidence_hash": evidence_hash,
+    }
+    old = validators_svc._now() - timedelta(days=2)
+    async with await database.new_session() as session:
+        await session.execute(
+            sa.insert(attestations_t).values(
+                attestation_hash="b" * 64,
+                account_id=account_id,
+                validator_id=validator_id,
+                validator_wallet=wallet,
+                assignment_id=assignment["assignment_id"],
+                probe_group_id=assignment["probe_group_id"],
+                grid_nonce=assignment["grid_nonce"],
+                evidence_hash=evidence_hash,
+                authority="authoritative",
+                quorum_status="finalized",
+                worker_id=assignment["target_worker_id"],
+                model=assignment["model"],
+                modality="text",
+                capability=assignment["capability"],
+                canary_kind=assignment["canary_kind"],
+                verdict="healthy",
+                signature="0x" + "11" * 65,
+                signature_status="verified",
+                payload=evidence_payload,
+                created=old,
+            )
+        )
+        await session.execute(
+            sa.update(assignments_t)
+            .where(assignments_t.c.id == assignment["assignment_id"])
+            .values(status="finalized", quorum_status="finalized", finalized=old)
+        )
+        await session.execute(
+            sa.update(probe_groups_t)
+            .where(probe_groups_t.c.id == assignment["probe_group_id"])
+            .values(status="finalized", quorum_status="finalized", finalized=old)
+        )
+        await session.commit()
+
+    deleted = await validators_svc.prune_validator_operational_history(
+        older_than_days=1,
+    )
+    assert deleted == {"assignments": 1, "probe_groups": 1}
+    async with await database.new_session() as session:
+        evidence = (
+            await session.execute(
+                sa.select(
+                    attestations_t.c.assignment_id,
+                    attestations_t.c.probe_group_id,
+                    attestations_t.c.payload,
+                )
+            )
+        ).mappings().one()
+    assert evidence["assignment_id"] is None
+    assert evidence["probe_group_id"] is None
+    assert evidence["payload"] == evidence_payload
 
 
 @pytest.mark.asyncio

--- a/grid_api/services/AGENTS.md
+++ b/grid_api/services/AGENTS.md
@@ -59,6 +59,12 @@ content sanitization, and reward settlement.
   `text.basic.v1` nodes receive only echo/arithmetic. Expected answers
   and Core's private verdict are not returned to nodes. The path remains non-economic and
   must not route production jobs, reward, slash, or write worker ledger rows.
+  Non-economic does not mean resource-free: Core permits at most one new text
+  group per worker/model per configured interval (one hour by default), stores
+  the challenge once on the shared group, and hydrates validator-specific
+  assignments at the API boundary. Finalized assignment/group machinery is
+  pruned after the configured retention window; signed attestations remain the
+  durable evidence record.
   New probes stop at assignment expiry; already-completed probes may deliver
   only during the bounded attestation grace window.
   Aggregate health may expose bounded counts, agreement/dispute rates,

--- a/grid_api/services/AGENTS.md
+++ b/grid_api/services/AGENTS.md
@@ -48,8 +48,11 @@ content sanitization, and reward settlement.
   assignment and authoritative vote per registered validator/group, and
   aggregates a conservative 3-of-5 preview quorum. Text groups use randomized
   exact-instruction, arithmetic, strict-JSON, calibrated 4K/16K/32K
-  context-retrieval, multistep logic, exact function-call, two-stage tool-chain,
-  stop-sequence, and gross token-limit families. Token-limit scoring uses
+  context-retrieval, multistep logic, restricted-AST Python function synthesis,
+  exact function-call, two-stage tool-chain, stop-sequence, and gross token-limit
+  families. The code scorer interprets only one bounded arithmetic return
+  expression against assignment-only hidden inputs; it must never `exec`,
+  import, call, or otherwise run worker-supplied code. Token-limit scoring uses
   Grid-side `o200k_base` counting over visible plus reasoning output, a
   length-style finish, and a documented cross-tokenizer tolerance;
   worker order must not determine the family. An accepted target-worker failure

--- a/grid_api/services/AGENTS.md
+++ b/grid_api/services/AGENTS.md
@@ -47,7 +47,7 @@ content sanitization, and reward settlement.
   registration per canonical account, builds shared probe groups, binds one
   assignment and authoritative vote per registered validator/group, and
   aggregates a conservative 3-of-5 preview quorum. Text groups use randomized
-  exact-instruction, arithmetic, strict-JSON, calibrated 4K/16K
+  exact-instruction, arithmetic, strict-JSON, calibrated 4K/16K/32K
   context-retrieval, multistep logic, exact function-call, two-stage tool-chain,
   stop-sequence, and gross token-limit families. Token-limit scoring uses
   Grid-side `o200k_base` counting over visible plus reasoning output, a

--- a/grid_api/services/tests/test_validator_challenges.py
+++ b/grid_api/services/tests/test_validator_challenges.py
@@ -17,6 +17,7 @@ from grid_api.services import den, validators
         ("json.object", "json.object", "text.structured.v1"),
         ("context.retrieve", "context.retrieve", "text.context.4k.v1"),
         ("context.retrieve.16k", "context.retrieve.16k", "text.context.16k.v1"),
+        ("context.retrieve.32k", "context.retrieve.32k", "text.context.32k.v1"),
         ("logic.steps", "logic.steps", "text.reasoning.multistep.v1"),
         ("tool.call", "tool.call", "text.tool_call.v1"),
         ("tool.chain", "tool.chain", "text.tool_chain.v1"),
@@ -146,17 +147,31 @@ def test_context_scoring_requires_only_the_exact_retrieved_token():
     assert validators._score_text_challenge(challenge, "The value is A1B2C3D4", 10) == "failed"
 
 
+@pytest.mark.parametrize("kind", ["context.retrieve.16k", "context.retrieve.32k"])
+def test_long_context_scoring_uses_the_same_exact_contract(kind):
+    challenge = _challenge(kind, "A1B2C3D4")
+
+    assert validators._score_text_challenge(challenge, "`A1B2C3D4`", 10) == "healthy"
+    assert validators._score_text_challenge(challenge, "A1B2C3D4 extra", 10) == "failed"
+
+
 def test_context_challenge_tiers_match_their_declared_token_windows():
     challenge_4k = validators._make_text_challenge("context.retrieve")
     challenge_16k = validators._make_text_challenge("context.retrieve.16k")
+    challenge_32k = validators._make_text_challenge("context.retrieve.32k")
 
     assert 3_000 <= den.count_tokens(challenge_4k["prompt"]) <= 5_000
     assert 14_000 <= den.count_tokens(challenge_16k["prompt"]) <= 18_000
+    assert 28_000 <= den.count_tokens(challenge_32k["prompt"]) <= 36_000
     assert challenge_4k["prompt"].count("\nrecord=") == 100
     assert challenge_16k["prompt"].count("\nrecord=") == 400
+    assert challenge_32k["prompt"].count("\nrecord=") == 800
     assert challenge_16k["kind"] == "context.retrieve.16k"
     assert challenge_16k["capability"] == "text.context.16k.v1"
+    assert challenge_32k["kind"] == "context.retrieve.32k"
+    assert challenge_32k["capability"] == "text.context.32k.v1"
     assert "expected" not in challenge_16k
+    assert "expected" not in challenge_32k
 
 
 def test_multistep_scoring_rejects_ambiguous_numeric_answers():
@@ -206,8 +221,20 @@ def test_16k_context_family_requires_its_exact_scorer_capability():
     assert capabilities == {"text.context.16k.v1"}
 
 
+def test_32k_context_family_requires_its_exact_scorer_capability():
+    kinds, capabilities = validators._supported_text_challenges(["text.context.32k.v1"])
+
+    assert kinds == ("context.retrieve.32k",)
+    assert capabilities == {"text.context.32k.v1"}
+
+
 def test_long_context_families_require_worker_advertised_headroom():
-    kinds = ("echo", "context.retrieve", "context.retrieve.16k")
+    kinds = (
+        "echo",
+        "context.retrieve",
+        "context.retrieve.16k",
+        "context.retrieve.32k",
+    )
 
     assert validators._worker_eligible_text_challenges(
         kinds,
@@ -220,6 +247,10 @@ def test_long_context_families_require_worker_advertised_headroom():
     assert validators._worker_eligible_text_challenges(
         kinds,
         {"max_context_length": 32_768},
+    ) == kinds[:-1]
+    assert validators._worker_eligible_text_challenges(
+        kinds,
+        {"max_context_length": 65_536},
     ) == kinds
     assert validators._worker_eligible_text_challenges(
         kinds,

--- a/grid_api/services/tests/test_validator_challenges.py
+++ b/grid_api/services/tests/test_validator_challenges.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import json
+import re
 
 import pytest
 
@@ -19,6 +20,7 @@ from grid_api.services import den, validators
         ("context.retrieve.16k", "context.retrieve.16k", "text.context.16k.v1"),
         ("context.retrieve.32k", "context.retrieve.32k", "text.context.32k.v1"),
         ("logic.steps", "logic.steps", "text.reasoning.multistep.v1"),
+        ("code.function", "code.function", "text.code.v1"),
         ("tool.call", "tool.call", "text.tool_call.v1"),
         ("tool.chain", "tool.chain", "text.tool_chain.v1"),
         ("stop.sequence", "stop.sequence", "text.stop_sequence.v1"),
@@ -182,6 +184,45 @@ def test_multistep_scoring_rejects_ambiguous_numeric_answers():
     assert validators._score_text_challenge(challenge, "420", 10) == "failed"
 
 
+def test_code_challenge_uses_hidden_tests_without_executing_worker_code():
+    challenge = validators._make_text_challenge("code.function")
+    match = re.search(
+        r"multiply x by (\d+), add (-?\d+), take the result modulo (\d+).*subtract (\d+)",
+        challenge["prompt"],
+    )
+    assert match is not None
+    multiplier, offset, modulus, adjustment = map(int, match.groups())
+    function_name = challenge["function_name"]
+    correct = (
+        f"def {function_name}(x):\n"
+        f"    return (({multiplier} * x + {offset}) % {modulus}) - {adjustment}"
+    )
+
+    assert challenge["test_inputs"]
+    assert repr(challenge["test_inputs"]) not in challenge["prompt"]
+    assert validators._score_text_challenge(challenge, correct, 10) == "healthy"
+    assert validators._score_text_challenge(
+        challenge,
+        correct.replace(f"- {adjustment}", f"- {adjustment + 1}"),
+        10,
+    ) == "failed"
+    assert validators._score_text_challenge(
+        challenge,
+        f"import os\n{correct}",
+        10,
+    ) == "failed"
+    assert validators._score_text_challenge(
+        challenge,
+        f"def {function_name}(x):\n    return __import__('os').system('id')",
+        10,
+    ) == "failed"
+    assert validators._score_text_challenge(
+        challenge,
+        f"```python\n{correct}\n```",
+        10,
+    ) == "failed"
+
+
 def test_correct_answer_over_latency_budget_is_slow(monkeypatch):
     monkeypatch.setattr(validators, "PROBE_LATENCY_BUDGET_SECONDS", 1)
     challenge = _challenge("echo", "ABCDEF12")
@@ -263,6 +304,13 @@ def test_tool_call_family_requires_its_exact_scorer_capability():
 
     assert kinds == ("tool.call",)
     assert capabilities == {"text.tool_call.v1"}
+
+
+def test_code_family_requires_its_exact_scorer_capability():
+    kinds, capabilities = validators._supported_text_challenges(["text.code.v1"])
+
+    assert kinds == ("code.function",)
+    assert capabilities == {"text.code.v1"}
 
 
 def test_tool_chain_family_requires_its_exact_scorer_capability():

--- a/grid_api/services/validators.py
+++ b/grid_api/services/validators.py
@@ -12,6 +12,7 @@ rows.
 from __future__ import annotations
 
 import asyncio
+import ast
 import hashlib
 import json
 import logging
@@ -378,6 +379,7 @@ _TEXT_CHALLENGE_KINDS = (
     "context.retrieve.16k",
     "context.retrieve.32k",
     "logic.steps",
+    "code.function",
     "tool.call",
     "tool.chain",
     "stop.sequence",
@@ -391,6 +393,7 @@ _TEXT_CHALLENGE_CAPABILITIES = {
     "context.retrieve.16k": "text.context.16k.v1",
     "context.retrieve.32k": "text.context.32k.v1",
     "logic.steps": "text.reasoning.multistep.v1",
+    "code.function": "text.code.v1",
     "tool.call": "text.tool_call.v1",
     "tool.chain": "text.tool_chain.v1",
     "stop.sequence": "text.stop_sequence.v1",
@@ -818,6 +821,31 @@ def _make_text_challenge(kind: str | None = None) -> dict[str, Any]:
         )
         kind = "logic.steps"
         capability = "text.reasoning.multistep.v1"
+    elif selected == "code.function":
+        function_name = f"transform_{secrets.token_hex(4)}"
+        multiplier = secrets.randbelow(8) + 2
+        offset = secrets.randbelow(41) - 20
+        modulus = secrets.randbelow(81) + 17
+        adjustment = secrets.randbelow(9) + 1
+        test_inputs: list[int] = []
+        while len(test_inputs) < 7:
+            value = secrets.randbelow(201) - 100
+            if value not in test_inputs:
+                test_inputs.append(value)
+        outputs = [
+            ((value * multiplier + offset) % modulus) - adjustment
+            for value in test_inputs
+        ]
+        expected = _canonical(outputs)
+        prompt = (
+            f"Write one Python function named {function_name} that accepts exactly one "
+            "integer argument named x. It must multiply x by "
+            f"{multiplier}, add {offset}, take the result modulo {modulus} using Python "
+            f"integer semantics, then subtract {adjustment}. Return only the function "
+            "definition with no markdown, imports, calls, annotations, or explanation."
+        )
+        kind = "code.function"
+        capability = "text.code.v1"
     elif selected == "tool.call":
         function_name = f"record_{secrets.token_hex(4)}"
         number_field = f"count_{secrets.token_hex(3)}"
@@ -955,6 +983,9 @@ def _make_text_challenge(kind: str | None = None) -> dict[str, Any]:
         challenge["steps"] = steps
     if selected == "stop.sequence":
         challenge["stop"] = stop
+    if selected == "code.function":
+        challenge["function_name"] = function_name
+        challenge["test_inputs"] = test_inputs
     return challenge
 
 
@@ -1017,6 +1048,90 @@ def _normalized_tool_chain(tool_chain: Any) -> str | None:
             return None
         normalized.append(json.loads(call))
     return _canonical(normalized)
+
+
+_CODE_BINARY_OPERATORS = {
+    ast.Add: lambda left, right: left + right,
+    ast.Sub: lambda left, right: left - right,
+    ast.Mult: lambda left, right: left * right,
+    ast.FloorDiv: lambda left, right: left // right,
+    ast.Mod: lambda left, right: left % right,
+}
+_CODE_VALUE_LIMIT = 10**12
+
+
+def _evaluate_code_expression(node: ast.AST, x: int) -> int:
+    if isinstance(node, ast.Name) and node.id == "x":
+        return x
+    if isinstance(node, ast.Constant) and type(node.value) is int:
+        if abs(node.value) > 1_000_000:
+            raise ValueError("integer literal is out of bounds")
+        return node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        value = _evaluate_code_expression(node.operand, x)
+        result = value if isinstance(node.op, ast.UAdd) else -value
+    elif isinstance(node, ast.BinOp) and type(node.op) in _CODE_BINARY_OPERATORS:
+        left = _evaluate_code_expression(node.left, x)
+        right = _evaluate_code_expression(node.right, x)
+        if isinstance(node.op, (ast.FloorDiv, ast.Mod)) and right == 0:
+            raise ValueError("division by zero")
+        result = _CODE_BINARY_OPERATORS[type(node.op)](left, right)
+    else:
+        raise ValueError("unsupported code expression")
+    if abs(result) > _CODE_VALUE_LIMIT:
+        raise ValueError("code result is out of bounds")
+    return result
+
+
+def _normalized_code_answer(challenge: dict[str, Any], text: str) -> str | None:
+    """Interpret a tiny arithmetic Python subset; never execute worker code."""
+    answer = _strip_think(text)
+    if not answer or len(answer.encode("utf-8")) > 4_096:
+        return None
+    function_name = challenge.get("function_name")
+    test_inputs = challenge.get("test_inputs")
+    if (
+        not isinstance(function_name, str)
+        or not re.fullmatch(r"transform_[0-9a-f]{8}", function_name)
+        or not isinstance(test_inputs, list)
+        or not 3 <= len(test_inputs) <= 16
+        or any(type(value) is not int or abs(value) > 1_000_000 for value in test_inputs)
+    ):
+        return None
+    try:
+        tree = ast.parse(answer, mode="exec")
+    except (SyntaxError, TypeError, ValueError):
+        return None
+    if len(list(ast.walk(tree))) > 64 or len(tree.body) != 1:
+        return None
+    function = tree.body[0]
+    if not isinstance(function, ast.FunctionDef) or function.name != function_name:
+        return None
+    args = function.args
+    if (
+        function.decorator_list
+        or function.returns is not None
+        or args.posonlyargs
+        or len(args.args) != 1
+        or args.args[0].arg != "x"
+        or args.args[0].annotation is not None
+        or args.vararg is not None
+        or args.kwonlyargs
+        or args.kwarg is not None
+        or args.defaults
+        or args.kw_defaults
+        or len(function.body) != 1
+        or not isinstance(function.body[0], ast.Return)
+    ):
+        return None
+    try:
+        outputs = [
+            _evaluate_code_expression(function.body[0].value, value)
+            for value in test_inputs
+        ]
+    except (ArithmeticError, TypeError, ValueError):
+        return None
+    return _canonical(outputs)
 
 
 def _normalized_text_answer(
@@ -1105,6 +1220,8 @@ def _score_text_challenge(
             reasoning_text,
             finish_reason,
         )
+    elif kind == "code.function":
+        candidate = _normalized_code_answer(challenge, text)
     else:
         candidate = _normalized_text_answer(kind, text, tool_calls, tool_chain)
     if candidate is None:
@@ -1156,7 +1273,8 @@ def _assignment_to_dict(
             if row["modality"] in {"image", "video"}
             else (
                 "kind", "prompt", "expected_hash", "max_tokens", "temperature",
-                "tools", "tool_choice", "steps", "stop",
+                "tools", "tool_choice", "steps", "stop", "function_name",
+                "test_inputs",
             )
         )
         out["challenge"] = {key: challenge[key] for key in keys if key in challenge}
@@ -1492,7 +1610,7 @@ async def issue_assignments(
                     "modality": "text",
                     "capability": challenge["capability"],
                     "canary_kind": challenge["kind"],
-                    "scoring_policy_id": "text.generated.v6",
+                    "scoring_policy_id": "text.generated.v7",
                     "challenge": challenge,
                     "challenge_hash": _hash_obj({
                         "group_id": group_id,

--- a/grid_api/services/validators.py
+++ b/grid_api/services/validators.py
@@ -451,6 +451,28 @@ def _worker_supports_text_capability(capability: str, worker: dict[str, Any]) ->
     return max_context >= _TEXT_CAPABILITY_MIN_WORKER_CONTEXT.get(capability, 0)
 
 
+async def _text_group_cooldown_active(
+    session,
+    *,
+    worker_id: str,
+    model: str,
+    now: datetime,
+) -> bool:
+    """Keep preview validation from becoming an unlimited free-work route."""
+    interval = max(
+        300,
+        int(get_settings().validator_text_group_min_interval_seconds),
+    )
+    latest = await session.scalar(
+        sa.select(sa.func.max(probe_groups_t.c.created)).where(
+            probe_groups_t.c.target_worker_id == worker_id,
+            probe_groups_t.c.model == model,
+            probe_groups_t.c.modality == "text",
+        )
+    )
+    return bool(latest and _aware(latest) >= now - timedelta(seconds=interval))
+
+
 def media_validation_policy() -> dict[str, Any]:
     """Return the fail-closed assignment gate without exposing private state."""
     settings = get_settings()
@@ -1141,6 +1163,31 @@ def _assignment_to_dict(
     return out
 
 
+async def _hydrate_assignment_challenges(session, rows) -> list[dict[str, Any]]:
+    """Resolve grouped assignments from the probe group's single challenge copy."""
+    hydrated = [dict(row) for row in rows]
+    group_ids = {
+        str(row["probe_group_id"])
+        for row in hydrated
+        if row.get("probe_group_id") and not (row.get("challenge") or {})
+    }
+    if not group_ids:
+        return hydrated
+    group_rows = (
+        await session.execute(
+            sa.select(probe_groups_t.c.id, probe_groups_t.c.challenge).where(
+                probe_groups_t.c.id.in_(group_ids)
+            )
+        )
+    ).mappings().all()
+    challenges = {str(row["id"]): row["challenge"] or {} for row in group_rows}
+    for row in hydrated:
+        group_id = row.get("probe_group_id")
+        if group_id and not (row.get("challenge") or {}):
+            row["challenge"] = challenges.get(str(group_id), {})
+    return hydrated
+
+
 async def _finalize_due_assignments(session) -> None:
     now = _now()
     group_deadline = now - timedelta(seconds=ATTESTATION_GRACE_SECONDS)
@@ -1230,6 +1277,38 @@ async def _finalize_due_assignments(session) -> None:
         )
 
 
+async def prune_validator_operational_history(
+    *,
+    older_than_days: int | None = None,
+) -> dict[str, int]:
+    """Prune finalized assignment/group machinery, never signed evidence."""
+    configured = get_settings().validator_history_retention_days
+    retention_days = max(1, int(older_than_days or configured))
+    cutoff = _now() - timedelta(days=retention_days)
+    async with await new_session() as session:
+        deleted_assignments = await session.execute(
+            sa.delete(assignments_t).where(
+                assignments_t.c.finalized.isnot(None),
+                assignments_t.c.finalized < cutoff,
+            )
+        )
+        remaining_assignments = sa.select(assignments_t.c.id).where(
+            assignments_t.c.probe_group_id == probe_groups_t.c.id
+        )
+        deleted_groups = await session.execute(
+            sa.delete(probe_groups_t).where(
+                probe_groups_t.c.finalized.isnot(None),
+                probe_groups_t.c.finalized < cutoff,
+                ~sa.exists(remaining_assignments),
+            )
+        )
+        await session.commit()
+    return {
+        "assignments": max(0, int(deleted_assignments.rowcount or 0)),
+        "probe_groups": max(0, int(deleted_groups.rowcount or 0)),
+    }
+
+
 async def issue_assignments(
     *,
     account_id,
@@ -1305,6 +1384,7 @@ async def issue_assignments(
                 .limit(safe_limit)
             )
         ).mappings().all()
+        existing = await _hydrate_assignment_challenges(session, existing)
         existing_keys = {(r["target_worker_id"], r["model"]) for r in existing}
         rows = list(existing)
 
@@ -1395,6 +1475,13 @@ async def issue_assignments(
                 continue
 
             if group is None:
+                if await _text_group_cooldown_active(
+                    session,
+                    worker_id=worker_id,
+                    model=model,
+                    now=now,
+                ):
+                    continue
                 challenge = _make_text_challenge(secrets.choice(eligible_challenge_kinds))
                 group_id = f"prg_{uuid4().hex}"
                 group_values = {
@@ -1458,7 +1545,9 @@ async def issue_assignments(
                 "probed": None,
                 "finalized": None,
             }
-            await session.execute(sa.insert(assignments_t).values(**values))
+            await session.execute(
+                sa.insert(assignments_t).values(**{**values, "challenge": {}})
+            )
             rows.append(values)
             existing_keys.add((worker_id, model))
 
@@ -1531,6 +1620,7 @@ async def _issue_image_assignments(
                 ).order_by(assignments_t.c.created.asc()).limit(limit)
             )
         ).mappings().all()
+        existing = await _hydrate_assignment_challenges(session, existing)
         rows = list(existing)
         existing_keys = {(str(row["target_worker_id"]), row["model"]) for row in existing}
 
@@ -1687,7 +1777,9 @@ async def _issue_image_assignments(
                     "probed": None,
                     "finalized": None,
                 }
-                await session.execute(sa.insert(assignments_t).values(**values))
+                await session.execute(
+                    sa.insert(assignments_t).values(**{**values, "challenge": {}})
+                )
                 rows.append(values)
                 existing_keys.add(key)
 
@@ -1758,6 +1850,7 @@ async def _issue_video_assignments(
                 ).order_by(assignments_t.c.created.asc()).limit(limit)
             )
         ).mappings().all()
+        existing = await _hydrate_assignment_challenges(session, existing)
         rows = list(existing)
         existing_keys = {(str(row["target_worker_id"]), row["model"]) for row in existing}
 
@@ -1889,7 +1982,9 @@ async def _issue_video_assignments(
                     "probed": None,
                     "finalized": None,
                 }
-                await session.execute(sa.insert(assignments_t).values(**values))
+                await session.execute(
+                    sa.insert(assignments_t).values(**{**values, "challenge": {}})
+                )
                 rows.append(values)
                 existing_keys.add(key)
 
@@ -3894,11 +3989,22 @@ async def _claim_probe_lease(
             )
         )
         await session.commit()
-        row = (
+        selected = (
             await session.execute(
-                sa.select(assignments_t).where(assignments_t.c.id == assignment_id)
+                sa.select(
+                    assignments_t,
+                    probe_groups_t.c.challenge.label("group_challenge"),
+                )
+                .outerjoin(
+                    probe_groups_t,
+                    probe_groups_t.c.id == assignments_t.c.probe_group_id,
+                )
+                .where(assignments_t.c.id == assignment_id)
             )
         ).mappings().first()
+        row = dict(selected) if selected else None
+        if row and not (row.get("challenge") or {}) and row.get("probe_group_id"):
+            row["challenge"] = row.get("group_challenge") or {}
 
     if not row:
         raise AssignmentError("assignment not found")

--- a/grid_api/services/validators.py
+++ b/grid_api/services/validators.py
@@ -376,6 +376,7 @@ _TEXT_CHALLENGE_KINDS = (
     "json.object",
     "context.retrieve",
     "context.retrieve.16k",
+    "context.retrieve.32k",
     "logic.steps",
     "tool.call",
     "tool.chain",
@@ -388,6 +389,7 @@ _TEXT_CHALLENGE_CAPABILITIES = {
     "json.object": "text.structured.v1",
     "context.retrieve": "text.context.4k.v1",
     "context.retrieve.16k": "text.context.16k.v1",
+    "context.retrieve.32k": "text.context.32k.v1",
     "logic.steps": "text.reasoning.multistep.v1",
     "tool.call": "text.tool_call.v1",
     "tool.chain": "text.tool_chain.v1",
@@ -401,6 +403,7 @@ _TEXT_CHALLENGE_CAPABILITIES = {
 _TEXT_CAPABILITY_MIN_WORKER_CONTEXT = {
     "text.context.4k.v1": 8_192,
     "text.context.16k.v1": 32_768,
+    "text.context.32k.v1": 65_536,
 }
 
 
@@ -734,8 +737,16 @@ def _make_text_challenge(kind: str | None = None) -> dict[str, Any]:
         )
         kind = "json.object"
         capability = "text.structured.v1"
-    elif selected in {"context.retrieve", "context.retrieve.16k"}:
-        record_count = 400 if selected == "context.retrieve.16k" else 100
+    elif selected in {
+        "context.retrieve",
+        "context.retrieve.16k",
+        "context.retrieve.32k",
+    }:
+        record_count = {
+            "context.retrieve": 100,
+            "context.retrieve.16k": 400,
+            "context.retrieve.32k": 800,
+        }[selected]
         target_index = secrets.randbelow(record_count)
         records: list[str] = []
         target_key = ""
@@ -756,11 +767,11 @@ def _make_text_challenge(kind: str | None = None) -> dict[str, Any]:
             + "\n".join(records)
         )
         kind = selected
-        capability = (
-            "text.context.16k.v1"
-            if selected == "context.retrieve.16k"
-            else "text.context.4k.v1"
-        )
+        capability = {
+            "context.retrieve": "text.context.4k.v1",
+            "context.retrieve.16k": "text.context.16k.v1",
+            "context.retrieve.32k": "text.context.32k.v1",
+        }[selected]
     elif selected == "logic.steps":
         value = secrets.randbelow(18) + 3
         start = value
@@ -1001,7 +1012,13 @@ def _normalized_text_answer(
         return _normalized_tool_chain(tool_chain)
     if not answer:
         return None
-    if kind in ("echo", "context.retrieve", "context.retrieve.16k", "stop.sequence"):
+    if kind in (
+        "echo",
+        "context.retrieve",
+        "context.retrieve.16k",
+        "context.retrieve.32k",
+        "stop.sequence",
+    ):
         candidate = _strip_wrapping_quotes(answer)
         return candidate if candidate and not re.search(r"\s", candidate) else None
     if kind == "json.object":

--- a/grid_api/v2/AGENTS.md
+++ b/grid_api/v2/AGENTS.md
@@ -46,6 +46,9 @@ snapshot pool.
   (NULL → grid defaults); SELECTed on the HOT auth path — their migrations
   (0009) must run before code that reads them.
 - `grid_validator_probe_groups` is the shared challenge and quorum lifecycle.
+  A grouped challenge is stored once on the probe group; grouped assignment
+  rows keep an empty challenge object and resolve the group copy when issued or
+  probed. Legacy ungrouped assignments continue to own their challenge.
   Media groups lease exactly one candidate-plus-two-reference execution and
   persist one response-committed frozen witness set for independent scoring by
   every assigned validator. Retries are bounded and stale leases reclaimable.
@@ -57,6 +60,10 @@ snapshot pool.
   Scorecards may aggregate them for
   operator/console visibility, but they must not be treated as economic truth
   until reward/dispute rules are live.
+  Finalized assignment and group rows are bounded operational state and may be
+  pruned after the configured retention window. Signed attestation rows and
+  their canonical payloads remain the durable evidence record; pruning must not
+  delete or rewrite them.
 - `grid_validators` binds one normalized signing wallet to one canonical account
   and records capabilities, version, and heartbeat. Assignment and attestation
   `validator_id` foreign keys preserve attribution; account uniqueness prevents

--- a/grid_api/v2/schema.py
+++ b/grid_api/v2/schema.py
@@ -761,6 +761,8 @@ validator_probe_groups = sa.Table(
     sa.Column("scoring_policy_id", sa.String(128), nullable=False),
     # The full challenge is Core-private. Assignment responses expose only the
     # prompt and one-way scoring commitment required for independent scoring.
+    # Legacy ungrouped assignments own a challenge. Shared-group assignments
+    # store {} and resolve the single authoritative copy from the probe group.
     sa.Column("challenge", PortableJSON, nullable=False, default=dict),
     sa.Column("challenge_hash", sa.String(64), nullable=False, unique=True),
     sa.Column("status", sa.String(24), nullable=False, default="pending", index=True),

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -74,6 +74,9 @@ account provisioning tools, and an incomplete testnet model-registry helper.
 - Put reusable logic in the owning service package and test it there.
 - Backup/restore tools must never print database credentials. Restore proof may
   only create or drop its generated `aipg_restore_proof_*` database.
+- A restore proof drops the default `public` schema only after creating and
+  selecting its guarded scratch database, because a schema-scoped archive must
+  recreate that schema. Never generalize this to a caller-supplied database.
 - Backups default to the Grid-owned `public` schema. `AIPG_BACKUP_SCHEMA` may
   select one explicit PostgreSQL identifier for a controlled migration, but a
   backup must never silently absorb unrelated extension schemas such as
@@ -86,6 +89,9 @@ account provisioning tools, and an incomplete testnet model-registry helper.
 - Run `bash -n scripts/payout_hourly.sh` for wrapper edits.
 - Run `bash -n scripts/backup_postgres.sh scripts/prove_postgres_restore.sh`
   and exercise both against disposable PostgreSQL before deployment.
+- Pull-request CI must run the PostgreSQL 16 backup/restore proof, including a
+  decoy non-Grid schema that the archive must exclude. A main-only proof is too
+  late to protect a deployment candidate.
 - Run focused settlement tests before changing payout invocation or periods.
 - Run `scripts/run_tests.sh` from an environment with
   `requirements.dev.txt` installed.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -32,8 +32,9 @@ account provisioning tools, and an incomplete testnet model-registry helper.
 - `verify_demand_canary.py` - read-only reconciliation of one canonical
   account's balance, reservations, purchased-credit refs, and worker ledger
   terminals.
-- `backup_postgres.sh` - root-only custom-format PostgreSQL backup with
-  checksum, archive validation, locking, and bounded local retention.
+- `backup_postgres.sh` - root-only custom-format backup of the Grid-owned
+  PostgreSQL schema with checksum, archive validation, locking, and bounded
+  local retention. It excludes unrelated extension and legacy schemas.
 - `prove_postgres_restore.sh` - restores one verified backup into a guarded
   disposable local database and migrates it with an immutable candidate.
 
@@ -73,6 +74,10 @@ account provisioning tools, and an incomplete testnet model-registry helper.
 - Put reusable logic in the owning service package and test it there.
 - Backup/restore tools must never print database credentials. Restore proof may
   only create or drop its generated `aipg_restore_proof_*` database.
+- Backups default to the Grid-owned `public` schema. `AIPG_BACKUP_SCHEMA` may
+  select one explicit PostgreSQL identifier for a controlled migration, but a
+  backup must never silently absorb unrelated extension schemas such as
+  `cron`.
 - Invoke Python operator tools through the selected release's `.venv/bin/python`;
   their env-based shebang assumes an already activated virtual environment.
 

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -10,6 +10,7 @@ umask 077
 
 BACKUP_DIR="${AIPG_BACKUP_DIR:-/var/lib/aipg-backup}"
 RETENTION_DAYS="${AIPG_BACKUP_RETENTION_DAYS:-14}"
+BACKUP_SCHEMA="${AIPG_BACKUP_SCHEMA:-public}"
 
 die() {
     echo "error: $*" >&2
@@ -20,6 +21,8 @@ for name in POSTGRES_USER POSTGRES_PASS POSTGRES_URL; do
     [[ -n "${!name:-}" ]] || die "$name is required"
 done
 [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]] || die "AIPG_BACKUP_RETENTION_DAYS must be a non-negative integer"
+[[ "$BACKUP_SCHEMA" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] ||
+    die "AIPG_BACKUP_SCHEMA must be one PostgreSQL identifier"
 [[ "$POSTGRES_URL" =~ ^([A-Za-z0-9._-]+):([0-9]{1,5})/([A-Za-z0-9_-]+)$ ]] ||
     die "POSTGRES_URL must use host:port/database form"
 
@@ -73,6 +76,7 @@ pg_dump \
     --port="$port" \
     --username="$POSTGRES_USER" \
     --dbname="$database" \
+    --schema="$BACKUP_SCHEMA" \
     --format=custom \
     --compress=9 \
     --file="$partial"

--- a/scripts/prove_postgres_restore.sh
+++ b/scripts/prove_postgres_restore.sh
@@ -143,6 +143,13 @@ else
     runuser -u postgres -- createdb --port="$port" --owner="$POSTGRES_USER" "$scratch"
 fi
 scratch_created=1
+psql \
+    --host="$host" \
+    --port="$port" \
+    --username="$POSTGRES_USER" \
+    --dbname="$scratch" \
+    --set=ON_ERROR_STOP=1 \
+    --command='DROP SCHEMA public'
 pg_restore \
     --exit-on-error \
     --no-owner \


### PR DESCRIPTION
## Summary

- add explicit `text.context.32k.v1` and `text.code.v1` validator capabilities
- calibrate randomized 32K retrieval prompts and require 65,536 advertised worker context
- add restricted-AST Python function synthesis against assignment-only hidden inputs
- rate-bound text probe groups per worker/model and retain one challenge copy per shared group
- retention-bound finalized assignment/group machinery while preserving signed attestations
- keep every validator result evidence-only and economically inert

## Security review

The initial 32K candidate allowed a full group to be replaced immediately after finalization. Five validator accounts could repeatedly force unpaid long-context GPU work and duplicate large challenges. Commit `81a4151b` closes that path with PostgreSQL-serialized per-worker/model cadence, single-copy group storage, API-boundary hydration, and bounded operational retention.

The code lane never executes worker output. Core parses one function with Python `ast` and interprets only bounded integer literals, `x`, unary signs, and `+ - * // %`. Imports, calls, attributes, decorators, annotations, extra statements, markdown, oversized ASTs/values, and wrong hidden-test behavior fail closed. Hidden inputs never enter the worker request.

## Verification

- full Core suite: `511 passed, 15 skipped`
- disposable PostgreSQL validator concurrency/retention suite: passed
- 100 generated 32K challenges: 31,089-31,472 `o200k_base` tokens; 66,517-byte maximum prompt
- paired Core/validator code contract: 200 randomized correct functions matched
- adversarial code corpus: 1,000 outputs rejected consistently by both implementations
- `python -m compileall`: passed
- `git diff --check`: clean

## Rollout

Source-only. Do not deploy independently of the paired validator PR. A real backend acceptance canary is still required before enabling either the 32K or code family in production. No live 32K/code workload, routing effect, payout, reward, strike, staking, or slashing authority is claimed.
